### PR TITLE
Add manual question import interface

### DIFF
--- a/import_questions.py
+++ b/import_questions.py
@@ -1,0 +1,109 @@
+from flask import Flask, render_template, request, jsonify
+import mysql.connector
+import json
+from config import DB_CONFIG
+
+app = Flask(__name__)
+
+@app.route('/')
+def index():
+    return render_template('import_questions.html')
+
+# --- Dropdown APIs ---
+@app.route('/api/providers')
+def api_providers():
+    conn = mysql.connector.connect(**DB_CONFIG)
+    cur = conn.cursor(dictionary=True)
+    cur.execute("SELECT id, name FROM provs")
+    rows = cur.fetchall()
+    cur.close(); conn.close()
+    return jsonify(rows)
+
+@app.route('/api/certifications/<int:prov_id>')
+def api_certs(prov_id):
+    conn = mysql.connector.connect(**DB_CONFIG)
+    cur = conn.cursor(dictionary=True)
+    cur.execute("SELECT id, name FROM courses WHERE prov = %s", (prov_id,))
+    rows = cur.fetchall()
+    cur.close(); conn.close()
+    return jsonify(rows)
+
+@app.route('/api/modules/<int:cert_id>')
+def api_modules(cert_id):
+    conn = mysql.connector.connect(**DB_CONFIG)
+    cur = conn.cursor(dictionary=True)
+    cur.execute("SELECT id, name FROM modules WHERE course = %s", (cert_id,))
+    rows = cur.fetchall()
+    cur.close(); conn.close()
+    return jsonify(rows)
+
+# --- Insert question ---
+@app.route('/api/questions', methods=['POST'])
+def api_questions():
+    data = request.get_json() or {}
+    module_id = data.get('module_id')
+    question = data.get('question')
+    if not module_id or not question:
+        return jsonify({'error': 'module_id and question are required'}), 400
+
+    scenario = question.get('scenario', 'no')
+    ty_mapping = {'no':1, 'scenario':2, 'scenario-illustrated':3}
+    level_mapping = {'easy':0, 'medium':1, 'hard':2}
+    nature_mapping = {
+        'qcm':1, 'truefalse':2, 'short-answer':3,
+        'matching':4, 'drag-n-drop':5
+    }
+
+    ty_num = ty_mapping.get(scenario, 1)
+    level_num = level_mapping.get(question.get('level', 'medium'), 1)
+    nature_num = nature_mapping.get(question.get('nature', 'qcm'), 1)
+
+    context = (question.get('context') or '').strip()
+    diagram_descr = (question.get('diagram_descr') or '').strip()
+    image = (question.get('image') or '').strip()
+    text = (question.get('text') or '').strip()
+
+    if context or image:
+        question_text = ''
+        if context:
+            question_text += context + '\n'
+        if image:
+            question_text += image + '<br>'
+        question_text += text
+    else:
+        question_text = text
+
+    conn = mysql.connector.connect(**DB_CONFIG)
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            "INSERT INTO questions (text, descr, level, module, nature, ty, created_at) VALUES (%s,%s,%s,%s,%s,%s,NOW())",
+            (question_text, diagram_descr, level_num, module_id, nature_num, ty_num)
+        )
+        question_id = cur.lastrowid
+        for ans in question.get('answers', []):
+            ans_data = {k:v for k,v in ans.items() if k != 'isok'}
+            ans_json = json.dumps(ans_data, ensure_ascii=False)
+            isok = ans.get('isok',0)
+            try:
+                cur.execute("INSERT INTO answers (text, created_at) VALUES (%s,NOW())", (ans_json,))
+                ans_id = cur.lastrowid
+            except mysql.connector.Error as e:
+                if e.errno == 1062:
+                    cur.execute("SELECT id FROM answers WHERE text=%s", (ans_json,))
+                    res = cur.fetchone()
+                    ans_id = res[0] if res else None
+                else:
+                    raise
+            if ans_id:
+                cur.execute("INSERT INTO quest_ans (question, answer, isok) VALUES (%s,%s,%s)", (question_id, ans_id, isok))
+        conn.commit()
+    except Exception as e:
+        conn.rollback()
+        cur.close(); conn.close()
+        return jsonify({'error': str(e)}), 500
+    cur.close(); conn.close()
+    return jsonify({'id': question_id})
+
+if __name__ == '__main__':
+    app.run(debug=True, port=9002)

--- a/templates/import_questions.html
+++ b/templates/import_questions.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Importer Questions</title>
+  <style>
+    body { font-family:sans-serif; padding:2rem; }
+    .panel { display:inline-block; width:45%; vertical-align:top;
+             border:1px solid #ccc; border-radius:6px; padding:1em; margin:1%; }
+    .field { margin:.5em 0; }
+    label { display:block; font-weight:bold; margin-bottom:.2em; }
+    select, textarea, button { width:100%; padding:.5em; font-size:1em; }
+    #progress { width:100%; background:#eee; border-radius:4px; overflow:hidden; margin-top:1em; }
+    #bar { width:0%; height:1em; background:#4caf50; transition:width .3s; }
+    #log { white-space:pre-wrap; background:#f9f9f9; padding:.5em; height:8em; overflow-y:auto; border:1px solid #ddd; margin-top:.5em; }
+  </style>
+</head>
+<body>
+  <h1>Importer des Questions</h1>
+  <div class="panel">
+    <div class="field">
+      <label for="prov">Provider</label>
+      <select id="prov"></select>
+    </div>
+    <div class="field">
+      <label for="cert">Certification</label>
+      <select id="cert"></select>
+    </div>
+    <div class="field">
+      <label for="mod">Domaine</label>
+      <select id="mod"></select>
+    </div>
+  </div>
+
+  <div class="panel">
+    <div class="field">
+      <label for="json-input">Collez le JSON des questions</label>
+      <textarea id="json-input" rows="12" placeholder='{"questions":[{"text":"Question text","scenario":"none","nature":"qcm","level":"medium","answers":[{"value":"A","isok":1},{"value":"B","isok":0}]}]}'></textarea>
+    </div>
+    <button id="import-btn">Importer</button>
+    <div id="progress"><div id="bar"></div></div>
+    <div id="log"></div>
+  </div>
+
+<script>
+async function loadJSON(url){ const r = await fetch(url); return r.json(); }
+function fill(sel, items){ sel.innerHTML=''; items.forEach(i=>{ const o=document.createElement('option'); o.value=i.id; o.text=i.name; sel.appendChild(o); }); }
+
+document.addEventListener('DOMContentLoaded', async()=>{
+  const provSel=document.getElementById('prov');
+  const certSel=document.getElementById('cert');
+  const modSel=document.getElementById('mod');
+  const provs=await loadJSON('/api/providers');
+  fill(provSel, provs);
+  provSel.value=provs[0]?.id; provSel.dispatchEvent(new Event('change'));
+
+  provSel.addEventListener('change', async()=>{
+    const cs=await loadJSON(`/api/certifications/${provSel.value}`);
+    fill(certSel, cs);
+    certSel.value=cs[0]?.id; certSel.dispatchEvent(new Event('change'));
+  });
+
+  certSel.addEventListener('change', async()=>{
+    const ms=await loadJSON(`/api/modules/${certSel.value}`);
+    fill(modSel, ms);
+  });
+});
+
+ document.getElementById('import-btn').onclick = async ()=>{
+    const moduleId=+document.getElementById('mod').value;
+    if(!moduleId) return alert('Module manquant');
+    let data;
+    try{ data=JSON.parse(document.getElementById('json-input').value); }
+    catch{ return alert('JSON invalide'); }
+    const questions=data.questions;
+    if(!Array.isArray(questions)) return alert('Format JSON attendu: {"questions":[...] }');
+    const total=questions.length;
+    const log=document.getElementById('log');
+    const bar=document.getElementById('bar');
+    log.textContent=''; bar.style.width='0%';
+    for(let i=0;i<total;i++){
+      const q=questions[i];
+      try{
+        const res=await fetch('/api/questions',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({module_id:moduleId, question:q})});
+        const j=await res.json();
+        if(res.ok) log.textContent+=`✓ [${j.id}]\n`;
+        else log.textContent+=`✗ ${j.error}\n`;
+      }catch(e){ log.textContent+=`✗ ${e}\n`; }
+      bar.style.width=Math.round((i+1)/total*100)+'%';
+    }
+    alert('Import terminé');
+ };
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `import_questions.py` Flask app for uploading questions from JSON
- add `import_questions.html` template with progress logging

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684777ac8ca48325a490a27bda1090b6