### PR TITLE
Unify web services under ExBoot Laboratory hub

### DIFF
--- a/dom.py
+++ b/dom.py
@@ -1,17 +1,17 @@
-from flask import Flask, render_template, request, jsonify
+from flask import Blueprint, render_template, request, jsonify
 import mysql.connector
 import json
 from config import DB_CONFIG
 
-app = Flask(__name__)
+dom_bp = Blueprint('dom', __name__)
 
 # --- Routes pour l’interface ---
-@app.route('/')
+@dom_bp.route('/')
 def index():
     return render_template('import_modules.html')
 
 # --- API pour remplir les dropdowns ---
-@app.route('/api/providers')
+@dom_bp.route('/api/providers')
 def api_providers():
     conn = mysql.connector.connect(**DB_CONFIG)
     cur  = conn.cursor(dictionary=True)
@@ -20,7 +20,7 @@ def api_providers():
     cur.close(); conn.close()
     return jsonify(rows)
 
-@app.route('/api/certifications/<int:prov_id>')
+@dom_bp.route('/api/certifications/<int:prov_id>')
 def api_certs(prov_id):
     conn = mysql.connector.connect(**DB_CONFIG)
     cur  = conn.cursor(dictionary=True)
@@ -30,7 +30,7 @@ def api_certs(prov_id):
     return jsonify(rows)
 
 # --- API pour créer un domaine (module) ---
-@app.route('/api/modules', methods=['POST'])
+@dom_bp.route('/api/modules', methods=['POST'])
 def api_create_module():
     data = request.get_json() or {}
     cert_id = data.get('certification_id')
@@ -57,5 +57,3 @@ def api_create_module():
 
     return jsonify({'id': new_id, 'name': name})
 
-if __name__ == '__main__':
-    app.run(debug=True, port=9001)

--- a/move.py
+++ b/move.py
@@ -1,8 +1,8 @@
-from flask import Flask, render_template, jsonify, request, g
+from flask import Blueprint, render_template, jsonify, request, g
 import mysql.connector
 from config import DB_CONFIG
 
-app = Flask(__name__)
+move_bp = Blueprint('move', __name__)
 
 def get_db():
     """Ouvre une connexion MySQL si nécessaire et la stocke dans g."""
@@ -16,18 +16,18 @@ def get_db():
         )
     return g.db
 
-@app.teardown_appcontext
+@move_bp.teardown_request
 def close_db(exc):
     """Ferme la connexion à la fin de la requête."""
     db = g.pop('db', None)
     if db is not None:
         db.close()
 
-@app.route('/')
+@move_bp.route('/')
 def index():
     return render_template('move_questions.html')
 
-@app.route('/api/providers')
+@move_bp.route('/api/providers')
 def api_providers():
     db = get_db()
     cur = db.cursor(dictionary=True)
@@ -36,7 +36,7 @@ def api_providers():
     cur.close()
     return jsonify(rows)
 
-@app.route('/api/certifications/<int:prov_id>')
+@move_bp.route('/api/certifications/<int:prov_id>')
 def api_certs(prov_id):
     db = get_db()
     cur = db.cursor(dictionary=True)
@@ -48,7 +48,7 @@ def api_certs(prov_id):
     cur.close()
     return jsonify(rows)
 
-@app.route('/api/domains/<int:cert_id>')
+@move_bp.route('/api/domains/<int:cert_id>')
 def api_domains(cert_id):
     db = get_db()
     cur = db.cursor(dictionary=True)
@@ -60,7 +60,7 @@ def api_domains(cert_id):
     cur.close()
     return jsonify(rows)
 
-@app.route('/api/move', methods=['POST'])
+@move_bp.route('/api/move', methods=['POST'])
 def api_move():
     data = request.get_json()
     src_modules = data.get('source_module_ids', [])
@@ -84,6 +84,3 @@ def api_move():
     cur.close()
 
     return jsonify({'moved': moved})
-
-if __name__ == '__main__':
-    app.run(debug=True, port=8000)  # <-- ajuste le port si besoin

--- a/quest.py
+++ b/quest.py
@@ -1,16 +1,16 @@
-from flask import Flask, render_template, request, jsonify
+from flask import Blueprint, render_template, request, jsonify
 import mysql.connector
 import json
 from config import DB_CONFIG
 
-app = Flask(__name__)
+quest_bp = Blueprint('quest', __name__)
 
-@app.route('/')
+@quest_bp.route('/')
 def index():
     return render_template('import_questions.html')
 
 # --- Dropdown APIs ---
-@app.route('/api/providers')
+@quest_bp.route('/api/providers')
 def api_providers():
     conn = mysql.connector.connect(**DB_CONFIG)
     cur = conn.cursor(dictionary=True)
@@ -19,7 +19,7 @@ def api_providers():
     cur.close(); conn.close()
     return jsonify(rows)
 
-@app.route('/api/certifications/<int:prov_id>')
+@quest_bp.route('/api/certifications/<int:prov_id>')
 def api_certs(prov_id):
     conn = mysql.connector.connect(**DB_CONFIG)
     cur = conn.cursor(dictionary=True)
@@ -28,7 +28,7 @@ def api_certs(prov_id):
     cur.close(); conn.close()
     return jsonify(rows)
 
-@app.route('/api/modules/<int:cert_id>')
+@quest_bp.route('/api/modules/<int:cert_id>')
 def api_modules(cert_id):
     conn = mysql.connector.connect(**DB_CONFIG)
     cur = conn.cursor(dictionary=True)
@@ -38,7 +38,7 @@ def api_modules(cert_id):
     return jsonify(rows)
 
 # --- Insert question (une par une) ---
-@app.route('/api/questions', methods=['POST'])
+@quest_bp.route('/api/questions', methods=['POST'])
 def api_questions():
     data = request.get_json() or {}
     module_id = data.get('module_id')
@@ -141,6 +141,4 @@ def api_questions():
 
     cur.close(); conn.close()
     return jsonify({'id': question_id, 'status': 'inserted'})
-    
-if __name__ == '__main__':
-    app.run(debug=True, port=9002)
+

--- a/reloc.py
+++ b/reloc.py
@@ -1,6 +1,6 @@
 # reloc.py
 
-from flask import Flask, render_template, request, Response
+from flask import Blueprint, render_template, request, Response
 import mysql.connector
 import requests
 import json
@@ -10,14 +10,14 @@ from config import OPENAI_API_KEY, OPENAI_MODEL, DB_CONFIG
 
 OPENAI_ENDPOINT = 'https://api.openai.com/v1/chat/completions'
 
-app = Flask(__name__)
+reloc_bp = Blueprint('reloc', __name__)
 
 # -- Routes pour remplir les dropdowns --
-@app.route('/')
+@reloc_bp.route('/')
 def index():
     return render_template('reloc.html')
 
-@app.route('/api/providers')
+@reloc_bp.route('/api/providers')
 def api_providers():
     conn = mysql.connector.connect(**DB_CONFIG)
     cur  = conn.cursor(dictionary=True)
@@ -26,7 +26,7 @@ def api_providers():
     cur.close(); conn.close()
     return json.dumps(rows, ensure_ascii=False), 200, {'Content-Type':'application/json'}
 
-@app.route('/api/certifications/<int:prov_id>')
+@reloc_bp.route('/api/certifications/<int:prov_id>')
 def api_certs(prov_id):
     conn = mysql.connector.connect(**DB_CONFIG)
     cur  = conn.cursor(dictionary=True)
@@ -35,7 +35,7 @@ def api_certs(prov_id):
     cur.close(); conn.close()
     return json.dumps(rows, ensure_ascii=False), 200, {'Content-Type':'application/json'}
 
-@app.route('/api/modules/<int:cert_id>')
+@reloc_bp.route('/api/modules/<int:cert_id>')
 def api_modules(cert_id):
     conn = mysql.connector.connect(**DB_CONFIG)
     cur  = conn.cursor(dictionary=True)
@@ -45,7 +45,7 @@ def api_modules(cert_id):
     return json.dumps(rows, ensure_ascii=False), 200, {'Content-Type':'application/json'}
 
 # -- SSE pour le streaming de la relocalisation --
-@app.route('/api/stream_relocate', methods=['GET'])
+@reloc_bp.route('/api/stream_relocate', methods=['GET'])
 def stream_relocate():
     src_module = request.args.get('source_module_id',    type=int)
     dst_cert    = request.args.get('destination_cert_id', type=int)
@@ -165,5 +165,3 @@ def stream_relocate():
     return Response(generate(), mimetype='text/event-stream')
 
 
-if __name__ == '__main__':
-    app.run(debug=True, port=9000)

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>ExBoot Laboratory</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="bg-gray-100">
+  <div class="max-w-2xl mx-auto p-8 mt-12 bg-white shadow-xl rounded">
+    <h1 class="text-4xl font-bold text-center mb-8">ExBoot Laboratory</h1>
+    <ul class="space-y-4 text-blue-600">
+      <li><a class="underline" href="{{ url_for('populate_index') }}">Populate Questions</a></li>
+      <li><a class="underline" href="{{ url_for('dom.index') }}">Import Modules</a></li>
+      <li><a class="underline" href="{{ url_for('move.index') }}">Move Questions</a></li>
+      <li><a class="underline" href="{{ url_for('reloc.index') }}">Relocate Questions</a></li>
+      <li><a class="underline" href="{{ url_for('pdf.index') }}">PDF Importer</a></li>
+      <li><a class="underline" href="{{ url_for('quest.index') }}">Manual Question Import</a></li>
+    </ul>
+  </div>
+</body>
+</html>

--- a/templates/import_modules.html
+++ b/templates/import_modules.html
@@ -64,14 +64,16 @@
     const provSel = document.getElementById('prov'),
           certSel = document.getElementById('cert');
 
+    const base = '{{ url_for('dom.index') }}';
+
     // Charge providers
-    const providers = await loadJSON('/api/providers');
+    const providers = await loadJSON(base + 'api/providers');
     fill(provSel, providers);
     provSel.value = providers[0]?.id;
 
     // Quand change provider => recharge certifications
     provSel.addEventListener('change', async ()=>{
-      const certs = await loadJSON(`/api/certifications/${provSel.value}`);
+      const certs = await loadJSON(`${base}api/certifications/${provSel.value}`);
       fill(certSel, certs);
     });
     // Trigger initial
@@ -102,7 +104,7 @@
         continue;
       }
       try {
-        const res = await fetch('/api/modules', {
+        const res = await fetch(base + 'api/modules', {
           method: 'POST',
           headers: {'Content-Type':'application/json'},
           body: JSON.stringify({

--- a/templates/import_questions.html
+++ b/templates/import_questions.html
@@ -50,18 +50,19 @@ document.addEventListener('DOMContentLoaded', async()=>{
   const provSel=document.getElementById('prov');
   const certSel=document.getElementById('cert');
   const modSel=document.getElementById('mod');
-  const provs=await loadJSON('/api/providers');
+  const base='{{ url_for('quest.index') }}';
+  const provs=await loadJSON(base+'api/providers');
   fill(provSel, provs);
   provSel.value=provs[0]?.id; provSel.dispatchEvent(new Event('change'));
 
   provSel.addEventListener('change', async()=>{
-    const cs=await loadJSON(`/api/certifications/${provSel.value}`);
+    const cs=await loadJSON(`${base}api/certifications/${provSel.value}`);
     fill(certSel, cs);
     certSel.value=cs[0]?.id; certSel.dispatchEvent(new Event('change'));
   });
 
   certSel.addEventListener('change', async()=>{
-    const ms=await loadJSON(`/api/modules/${certSel.value}`);
+    const ms=await loadJSON(`${base}api/modules/${certSel.value}`);
     fill(modSel, ms);
   });
 });
@@ -89,7 +90,7 @@ function parseFlexibleJSON(txt){
     for(let i=0;i<total;i++){
       const q=questions[i];
       try{
-        const res=await fetch('/api/questions',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({module_id:moduleId, question:q})});
+        const res=await fetch(base+'api/questions',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({module_id:moduleId, question:q})});
         const j=await res.json();
         if(res.ok) log.textContent+=`✓ [${j.id}]\n`;
         else log.textContent+=`✗ ${j.error}\n`;

--- a/templates/move_questions.html
+++ b/templates/move_questions.html
@@ -75,6 +75,8 @@ function fillSelect(el, items, addAll=false){
   });
 }
 
+const base = '{{ url_for('move.index') }}';
+
 async function initPanel(prefix){
   const prov = document.getElementById(prefix+'-prov');
   const cert = document.getElementById(prefix+'-cert');
@@ -82,7 +84,7 @@ async function initPanel(prefix){
   const isSource = prefix === 'src';
 
   // 1) charger providers
-  const provs = await loadJSON('/api/providers');
+  const provs = await loadJSON(base + 'api/providers');
   fillSelect(prov, provs);
   if (provs.length) {
     prov.value = provs[0].id;
@@ -90,7 +92,7 @@ async function initPanel(prefix){
   }
 
   prov.addEventListener('change', async ()=>{
-    const cs = await loadJSON(`/api/certifications/${prov.value}`);
+    const cs = await loadJSON(`${base}api/certifications/${prov.value}`);
     fillSelect(cert, cs);
     if (cs.length) {
       cert.value = cs[0].id;
@@ -99,7 +101,7 @@ async function initPanel(prefix){
   });
 
   cert.addEventListener('change', async ()=>{
-    const ds = await loadJSON(`/api/domains/${cert.value}`);
+    const ds = await loadJSON(`${base}api/domains/${cert.value}`);
     fillSelect(dom, ds, isSource);
   });
 }
@@ -112,7 +114,7 @@ document.addEventListener('DOMContentLoaded', ()=>{
     // source
     const srcDomValue = document.getElementById('src-dom').value;
     const srcModuleIds = srcDomValue === '__all__'
-      ? (await loadJSON(`/api/domains/${document.getElementById('src-cert').value}`)).map(d=>d.id)
+      ? (await loadJSON(`${base}api/domains/${document.getElementById('src-cert').value}`)).map(d=>d.id)
       : [parseInt(srcDomValue)];
 
     // destination
@@ -122,7 +124,7 @@ document.addEventListener('DOMContentLoaded', ()=>{
     }
     const dstModuleId = parseInt(dstDomValue);
 
-    const resp = await fetch('/api/move', {
+    const resp = await fetch(base + 'api/move', {
       method: 'POST',
       headers: {'Content-Type':'application/json'},
       body: JSON.stringify({

--- a/templates/populate.html
+++ b/templates/populate.html
@@ -14,7 +14,7 @@
     
     {% if not is_populating %}
     <!-- Formulaire de sélection -->
-    <form id="select-form" method="POST" action="/" class="space-y-6">
+    <form id="select-form" method="POST" action="{{ url_for('populate_index') }}" class="space-y-6">
       <div>
         <label for="provider_id" class="block text-lg font-medium text-gray-700">Provider:</label>
         <select name="provider_id" id="provider_id" class="mt-1 block w-full rounded border-gray-300 shadow-sm">
@@ -82,7 +82,7 @@
     $(document).ready(function(){
         // Charger les certifications quand un provider est sélectionné.
         $("#provider_id").change(function(){
-            $.post("/get_certifications", { provider_id: $(this).val() }, function(data){
+            $.post("{{ url_for('get_certifications') }}", { provider_id: $(this).val() }, function(data){
                 $("#cert_id").empty();
                 $.each(data, function(i, item){
                     $("#cert_id").append($("<option>", { 
@@ -101,7 +101,7 @@
             $("#analysisResult").text("En attente...");
             $("#domainCounter").text("0 / 0");
             $("#questionCounter").text("0");
-            $.post("/populate_process", {
+            $.post("{{ url_for('populate_process') }}", {
                 provider_id: "{{ provider_id }}",
                 cert_id: "{{ cert_id }}"
             }, function(response){
@@ -128,14 +128,14 @@
 
         // Bouton de pause
         $("#pausePopulate").click(function(){
-            $.post("/pause_populate", {}, function(response){
+            $.post("{{ url_for('pause_populate') }}", {}, function(response){
                 $("#logList").append("<li>Processus mis en pause.</li>");
             }, "json");
         });
 
         // Bouton de reprise
         $("#resumePopulate").click(function(){
-            $.post("/resume_populate", {}, function(response){
+            $.post("{{ url_for('resume_populate') }}", {}, function(response){
                 $("#logList").append("<li>Processus repris.</li>");
             }, "json");
         });

--- a/templates/reloc.html
+++ b/templates/reloc.html
@@ -51,19 +51,21 @@ async function initPanel(pref, hasModule){
   const c = document.getElementById(pref+'-cert');
   const m = hasModule && document.getElementById(pref+'-mod');
 
-  const provs = await loadJSON('/api/providers');
+  const base = '{{ url_for('reloc.index') }}';
+
+  const provs = await loadJSON(base + 'api/providers');
   fill(p, provs);
   p.value = provs[0]?.id; p.dispatchEvent(new Event('change'));
 
   p.addEventListener('change', async()=>{
-    const cs = await loadJSON(`/api/certifications/${p.value}`);
+    const cs = await loadJSON(`${base}api/certifications/${p.value}`);
     fill(c, cs);
     c.value = cs[0]?.id; c.dispatchEvent(new Event('change'));
   });
 
   if(!m) return;
   c.addEventListener('change', async()=>{
-    const ms = await loadJSON(`/api/modules/${c.value}`);
+    const ms = await loadJSON(`${base}api/modules/${c.value}`);
     fill(m, ms);
   });
 }
@@ -82,7 +84,8 @@ document.addEventListener('DOMContentLoaded', ()=>{
       destination_cert_id: dstCert,
       batch_size:          10
     });
-    const evt = new EventSource(`/api/stream_relocate?${params}`);
+    const base = '{{ url_for('reloc.index') }}';
+    const evt = new EventSource(`${base}api/stream_relocate?${params}`);
     const bar = document.getElementById('bar'),
           log = document.getElementById('log');
     let batches = 0;

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -51,8 +51,10 @@ function option(text, value) {
     return o;
 }
 
+const base = '{{ url_for('pdf.index') }}';
+
 // 1) Providers -> auto-sélection + cascade
-fetch("/api/providers").then(r => r.json()).then(data => {
+fetch(base + "api/providers").then(r => r.json()).then(data => {
     const providerSelect = document.getElementById("providerSelect");
     providerSelect.innerHTML = "";
     if (!data || data.length === 0) {
@@ -79,7 +81,7 @@ document.getElementById("providerSelect").addEventListener("change", function ()
         return;
     }
 
-    fetch(`/api/certifications/${prov_id}`).then(r => r.json()).then(data => {
+    fetch(`${base}api/certifications/${prov_id}`).then(r => r.json()).then(data => {
         certSelect.innerHTML = "";
         if (!data || data.length === 0) {
             certSelect.appendChild(option("— Aucune certification —", ""));
@@ -106,7 +108,7 @@ document.getElementById("certSelect").addEventListener("change", function () {
         return;
     }
 
-    fetch(`/api/modules/${cert_id}`).then(r => r.json()).then(data => {
+    fetch(`${base}api/modules/${cert_id}`).then(r => r.json()).then(data => {
         modSelect.innerHTML = "";
         if (!data || data.length === 0) {
             modSelect.appendChild(option("— Aucun module —", ""));
@@ -128,7 +130,7 @@ document.getElementById("uploadForm").addEventListener("submit", async function(
 
     try {
         const formData = new FormData(this);
-        const res = await fetch("/upload-pdf", { method: "POST", body: formData });
+        const res = await fetch(base + "upload-pdf", { method: "POST", body: formData });
         const data = await res.json();
         if (data.status === "ok") {
             currentSession = data.session_id;
@@ -154,7 +156,7 @@ document.getElementById("confirmImport").addEventListener("click", async functio
     formData.append("session_id", currentSession);
 
     try {
-        const res = await fetch("/import-questions", { method: "POST", body: formData });
+        const res = await fetch(base + "import-questions", { method: "POST", body: formData });
         const data = await res.json();
         if (data.status === "ok") {
             alert(`✅ Import terminé : ${data.imported_questions} questions, ${data.imported_answers} réponses`);


### PR DESCRIPTION
## Summary
- consolidate standalone Flask apps into a single application
- add "ExBoot Laboratory" landing page with links to all tools
- adapt routes and templates to use blueprints and prefixed APIs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'openai_api')*


------
https://chatgpt.com/codex/tasks/task_e_68a64f6226cc8325a27a88eb0786f0a1