### PR TITLE
Fix module importer base reference

### DIFF
--- a/templates/import_modules.html
+++ b/templates/import_modules.html
@@ -62,6 +62,8 @@
   </div>
 
 <script>
+  const base = '{{ url_for('dom.index') }}';
+
   async function loadJSON(url) {
     const res = await fetch(url);
     return res.json();
@@ -80,8 +82,6 @@
   document.addEventListener('DOMContentLoaded', async ()=>{
     const provSel = document.getElementById('prov'),
           certSel = document.getElementById('cert');
-
-    const base = '{{ url_for('dom.index') }}';
 
     // Charge providers
     const providers = await loadJSON(base + 'api/providers');


### PR DESCRIPTION
## Summary
- define `base` URL globally in module import template to avoid `base is not defined` errors during imports

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5c0f9fffc83258fcae6c7044980bd