### PR TITLE
Harden question population workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,50 @@
+# ExbootGen
+
+## Configuration des variables d'environnement
+
+L'application lit plusieurs variables d'environnement pour configurer l'accès à l'API OpenAI et contrôler le taux d'envoi des requêtes. Les variables principales sont :
+
+- `OPENAI_API_KEY` : clé API OpenAI (obligatoire)
+- `OPENAI_API_URL` : URL de l'endpoint Chat Completions (optionnel)
+- `OPENAI_MAX_RETRIES` : nombre maximal de tentatives en cas d'échec (optionnel)
+- `API_REQUEST_DELAY` : délai entre deux requêtes lors de la population (optionnel)
+
+### Sous Windows – PowerShell
+Pour définir des variables pour la session en cours :
+
+```powershell
+$env:OPENAI_API_KEY = "sk-votre-cle"
+$env:OPENAI_API_URL = "https://api.openai.com/v1/chat/completions"
+$env:OPENAI_MAX_RETRIES = "5"
+$env:API_REQUEST_DELAY = "1"
+```
+
+Pour enregistrer ces variables de manière permanente :
+
+```powershell
+setx OPENAI_API_KEY "sk-votre-cle"
+setx OPENAI_API_URL "https://api.openai.com/v1/chat/completions"
+setx OPENAI_MAX_RETRIES "5"
+setx API_REQUEST_DELAY "1"
+```
+
+### Sous Windows – Invite de commandes (cmd)
+Pour la session uniquement :
+
+```cmd
+set OPENAI_API_KEY=sk-votre-cle
+set OPENAI_API_URL=https://api.openai.com/v1/chat/completions
+set OPENAI_MAX_RETRIES=5
+set API_REQUEST_DELAY=1
+```
+
+Pour une configuration persistante :
+
+```cmd
+setx OPENAI_API_KEY "sk-votre-cle"
+setx OPENAI_API_URL "https://api.openai.com/v1/chat/completions"
+setx OPENAI_MAX_RETRIES "5"
+setx API_REQUEST_DELAY "1"
+```
+
+Après avoir défini les variables avec `setx`, redémarrez votre terminal pour qu'elles soient prises en compte.

--- a/config.py
+++ b/config.py
@@ -1,6 +1,15 @@
-# config.py
+"""Application configuration values.
 
+This module centralises runtime configuration, including database access and
+OpenAI settings.  Sensitive values such as the OpenAI API key are read from the
+environment to avoid committing secrets to version control.
+"""
+
+import os
+
+# ---------------------------------------------------------------------------
 # Database configuration
+# ---------------------------------------------------------------------------
 DB_CONFIG = {
     "host": "x.x.x.x",
     "user": "user",
@@ -8,11 +17,40 @@ DB_CONFIG = {
     "database": "db",
 }
 
+# ---------------------------------------------------------------------------
 # OpenAI configuration
-OPENAI_API_KEY = "sk-key"
-OPENAI_MODEL   = "o4-mini"
+# ---------------------------------------------------------------------------
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
+OPENAI_MODEL = "o4-mini"
+OPENAI_API_URL = os.environ.get(
+    "OPENAI_API_URL", "https://api.openai.com/v1/chat/completions"
+)
+OPENAI_MAX_RETRIES = int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
 
-# Distribution table: numbers of questions per difficulty, question type, and scenario style.
+# Delay (in seconds) between two consecutive calls to the OpenAI API during the
+# populate process.  This value can be tuned via the ``API_REQUEST_DELAY``
+# environment variable.
+API_REQUEST_DELAY = float(os.environ.get("API_REQUEST_DELAY", "1"))
+
+# ---------------------------------------------------------------------------
+# Question distribution
+# ---------------------------------------------------------------------------
+# ``DISTRIBUTION`` defines how many questions must be generated for each
+# difficulty level.  It is a nested mapping following the structure:
+#
+# ``{difficulty: {question_type: {scenario_style: target_count}}}``
+#
+# Example::
+#
+#     DISTRIBUTION = {
+#         "easy": {
+#             "qcm": {"no": 10, "scenario": 0, "scenario-illustrated": 0},
+#             "truefalse": {"no": 5, "scenario": 0, "scenario-illustrated": 0},
+#         }
+#     }
+#
+# meaning that for the "easy" level we expect 10 multiple-choice questions
+# without scenario and 5 true/false questions without scenario.
 
 DISTRIBUTION = {
     "easy": {
@@ -27,10 +65,11 @@ DISTRIBUTION = {
         "matching": {"no": 1, "scenario": 4, "scenario-illustrated": 4},
         "drag-n-drop": {"no": 1, "scenario": 4, "scenario-illustrated": 4},
     },
-    "easy": {
+    "hard": {
         "qcm": {"no": 2, "scenario": 6, "scenario-illustrated": 6},
         "truefalse": {"no": 2, "scenario": 0, "scenario-illustrated": 0},
         "matching": {"no": 1, "scenario": 5, "scenario-illustrated": 5},
         "drag-n-drop": {"no": 1, "scenario": 5, "scenario-illustrated": 5},
-    }
+    },
 }
+

--- a/tests/test_generate_questions.py
+++ b/tests/test_generate_questions.py
@@ -1,12 +1,17 @@
+import sys
+import os
 import unittest
 from unittest.mock import patch
 import json
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 import openai_api
 
 class DummyResponse:
     def __init__(self, questions):
         self._questions = questions
+        self.status_code = 200
     def json(self):
         content = json.dumps({"questions": [{"text": q} for q in self._questions]})
         return {"choices": [{"message": {"content": content}}]}

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+# Ensure API key env var before importing app
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+import app
+
+
+class ProcessDomainByDifficultyTest(unittest.TestCase):
+    def test_generates_and_inserts_questions_with_secondaries(self):
+        inserted = []
+        generated_args = {}
+
+        def fake_count_questions_in_category(domain_id, level, qtype, scenario_type):
+            return 0
+
+        def fake_get_domains_description_by_certif(cert_id):
+            return [{"id": 1, "descr": "desc"}]
+
+        def fake_generate_questions(**kwargs):
+            generated_args.update(kwargs)
+            return {"questions": [{"text": "q"}]}
+
+        def fake_insert_questions(domain_id, questions, scenario_type):
+            inserted.append((domain_id, scenario_type, questions))
+
+        with patch('app.db.count_questions_in_category', side_effect=fake_count_questions_in_category), \
+             patch('app.db.get_domains_description_by_certif', side_effect=fake_get_domains_description_by_certif), \
+             patch('app.generate_questions', side_effect=fake_generate_questions), \
+             patch('app.db.insert_questions', side_effect=fake_insert_questions), \
+             patch('app.pick_secondary_domains', return_value=['Sec']), \
+             patch('app.pause_event.wait', return_value=True), \
+             patch('app.time.sleep', return_value=None):
+            log = app.process_domain_by_difficulty(
+                domain_id=1,
+                domain_name='Dom',
+                difficulty='easy',
+                distribution={'qcm': {'scenario': 1}},
+                provider_name='Prov',
+                cert_id=10,
+                cert_name='Cert',
+                analysis={'case': '1'},
+                progress_log=[],
+                all_domain_names=['Dom', 'Sec']
+            )
+
+        self.assertEqual(generated_args['domain'], 'main domain :Dom; includes context from domains: Sec')
+        self.assertEqual(inserted[0][0], 1)
+        self.assertEqual(inserted[0][1], 'scenario')
+        self.assertTrue(any('Secondary domains' in entry for entry in log))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- pass certification context and IDs through `process_domain_by_difficulty`
- add retry with exponential backoff and configurable API endpoint/key
- document distribution structure and add API throttling delay
- improve logging and error handling, with pause support
- add unit tests for population logic and adjust existing tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5cc29b9b8832584cbfe5370c5123c