### PR TITLE
Add PDF-based question generator

### DIFF
--- a/openai_api.py
+++ b/openai_api.py
@@ -92,7 +92,8 @@ def generate_questions(
     practical: str,
     scenario_illustration_type: str,
     num_questions: int,
-    batch_size: int = 5
+    batch_size: int = 5,
+    use_text: bool = False
  ) -> dict:
     """
     Interroge l'API OpenAI pour générer des questions,
@@ -115,6 +116,7 @@ def generate_questions(
     logging.debug(f"domain: {domain}")
     logging.debug(f"description: {domain_descr}")
     logging.debug(f"level: {level}")
+    scope_phrase = "from the text provided" if use_text else "from the identified domains"
     
    # Always initialize text_for_diagram_type to ensure it's defined.
     text_for_diagram_type = ""
@@ -131,19 +133,19 @@ def generate_questions(
             )
         elif scenario_illustration_type == 'archi':
             specific_question_quality = (
-                "Based on a realistic technical design/architecture integrating concepts from the identified domains. The question aims to assess skills in understanding, design, diagnosis and/or improvement of infrastructure and architecture." 
+                "Based on a realistic technical design/architecture integrating concepts from the identified domains. The question aims to assess skills in understanding, design, diagnosis and/or improvement of infrastructure and architecture."
             )
         elif scenario_illustration_type == 'config':
             specific_question_quality = (
-                "Based on a described Configuration process integrating concepts from the identified domains. the question aims to assess skills in understanding, analysis, diagnosis and/or improvement of a configuration." 
-            )            
+                "Based on a described Configuration process integrating concepts from the identified domains. the question aims to assess skills in understanding, analysis, diagnosis and/or improvement of a configuration."
+            )
         elif scenario_illustration_type == 'console':
             specific_question_quality = (
-                "Based on a realistic console output integrating concepts from the identified domains. the question aims to assess skills in understanding, correction and/or execution of a task using command lines." 
+                "Based on a realistic console output integrating concepts from the identified domains. the question aims to assess skills in understanding, correction and/or execution of a task using command lines."
             )
         elif scenario_illustration_type == 'code':
             specific_question_quality = (
-                "The question aims to assess skills in understanding, correction and/or code writing. A code example may be present or not and integrate concepts from the identified domains." 
+                "The question aims to assess skills in understanding, correction and/or code writing. A code example may be present or not and integrate concepts from the identified domains."
             )
         else:
             specific_question_quality = (
@@ -157,7 +159,7 @@ def generate_questions(
         elif scenario_illustration_type == 'config':
             specific_question_quality = (
                 "Based on a described Configuration process integrating concepts from the identified domains. the question aims to assess skills in understanding, analysis, diagnosis and/or improvement of a configuration. Illustrate the context of the question with a diagram. To do so, provides a detailed textual description of the intended diagram in the 'diagram_descr' key, specifying components, relationships, connection links if it is a network, any relevant annotations. Set the value of 'diagram_type' json key to 'architecture'" #  The type of the diagram can be: architecture"
-            )            
+            )
         elif scenario_illustration_type == 'console':
             specific_question_quality = (
                 "Based on a realistic console output integrating concepts from the identified domains. the question aims to assess skills in understanding, correction and/or execution of a task using command lines. Illustrate the context of the question with a diagram. To do so, provides a detailed textual description of the intended diagram in the 'diagram_descr' key, specifying components, relationships, connection links if it is a network, any relevant annotations. Set the value of 'diagram_type' json key to 'architecture'" # the selected diagram type  The type of the diagram can be: architecture"
@@ -307,6 +309,8 @@ def generate_questions(
         )
         response_format = ""
     
+    specific_question_quality = specific_question_quality.replace("from the identified domains", scope_phrase)
+
     all_questions = []
     remaining = num_questions
 
@@ -314,12 +318,29 @@ def generate_questions(
         current = min(batch_size, remaining)
 
         # Construction du prompt pour ce batch
-        data = {
-            "model": OPENAI_MODEL,
-            "messages": [
-                {
-                    'role': 'user',
-                    'content': f"""
+        if use_text:
+            content_prompt = f"""
+TASK: Use the provided text to generate {current} questions on the {domain} topic of the {certification} course. 
+Provided text: {domain_descr}
+Questions: {question_type_text}
+Difficulty level: {level}: {level_explained}
+Practice: {practical}
+{scenario_illustration_type}
+Reference: Provided text.
+
+{specific_question_quality}
+
+Format your response as a decodable single-line JSON object.
+RESPONSE FORMAT (JSON only, no additional text):
+{response_format}
+
+RULES:
+1. If you want to present a line of code in your response, surround that portion with '[code]...[/code]'. This will help in formatting it.
+2. If you want to present a console command or result in your response, surround that portion with '[console]...[/console]'. This will help in formatting it.
+3. Strictly align questions to the content of the syllabus of the domain selected for the indicated certification.
+"""
+        else:
+            content_prompt = f"""
 TASK: Retrieve the official course content of the domain {domain} of {certification} certification exam and generate {current} questions for that specific domain.
 Main domain description: {domain_descr}
 Questions: {question_type_text}
@@ -339,6 +360,13 @@ RULES:
 2. If you want to present a console command or result in your response, surround that portion with '[console]...[/console]'. This will help in formatting it.
 3. Strictly align questions to the content of the syllabus of the domain selected for the indicated certification.
 """
+
+        data = {
+            "model": OPENAI_MODEL,
+            "messages": [
+                {
+                    'role': 'user',
+                    'content': content_prompt
                 }
             ]
         }

--- a/pdf_importer.py
+++ b/pdf_importer.py
@@ -6,7 +6,7 @@ from flask import Blueprint, request, jsonify, render_template
 from werkzeug.utils import secure_filename
 
 from routes_pdf import detect_questions, extract_text_from_pdf, db_conn
-from openai_api import generate_questions as ai_generate_questions
+from openai_api import generate_questions
 from config import DISTRIBUTION, API_REQUEST_DELAY
 
 # -------- Blueprint / Templates --------
@@ -17,7 +17,7 @@ UPLOAD_DIR = BASE_DIR / "uploads"
 os.makedirs(UPLOAD_DIR, exist_ok=True)
 
 # Mémoire légère (session d’analyse)
-SESSIONS = {}  # { session_id: { "module_id": int, "questions": [...] } }
+SESSIONS = {}  # { session_id: { "domain_id": int, "questions": [...] } }
 
 # -------- Mappings (text -> code BD) --------
 LEVEL_MAP = {"easy": 0, "medium": 1, "hard": 2}
@@ -92,6 +92,7 @@ def api_certifications(provider_id):
         conn.close()
 
 @pdf_bp.route("/api/modules/<int:cert_id>")
+@pdf_bp.route("/api/domains/<int:cert_id>")
 def api_modules(cert_id):
     conn = db_conn()
     try:
@@ -148,13 +149,16 @@ def generate_questions_from_pdf():
     try:
         provider_id = int(request.form.get("provider_id", 0))
         cert_id = int(request.form.get("cert_id", 0))
-        module_id = int(request.form.get("module_id", 0))
+        domain_id = int(request.form.get("domain_id", 0))
         num_questions = int(request.form.get("num_questions", 0))
     except ValueError:
         return jsonify({"status": "error", "message": "Paramètres invalides"}), 400
 
     use_distribution = request.form.get("use_distribution") == "on"
     q_type = request.form.get("q_type", "qcm")
+    level = request.form.get("level", "medium")
+    scenario = request.form.get("scenario", "no")
+    scenario_illustration_type = request.form.get("scenario_illustration_type", "none")
 
     pdf_file = request.files.get("pdf_file")
     if not pdf_file or not pdf_file.filename.lower().endswith(".pdf"):
@@ -182,7 +186,7 @@ def generate_questions_from_pdf():
     if not text.strip():
         return jsonify({"status": "error", "message": "PDF vide"}), 400
 
-    # Récupération des noms provider et certification
+    # Récupération des noms provider, certification et domaine
     conn = db_conn()
     try:
         cur = conn.cursor()
@@ -190,6 +194,8 @@ def generate_questions_from_pdf():
         prov_row = cur.fetchone()
         cur.execute("SELECT name FROM courses WHERE id=%s", (cert_id,))
         cert_row = cur.fetchone()
+        cur.execute("SELECT name FROM modules WHERE id=%s", (domain_id,))
+        dom_row = cur.fetchone()
     finally:
         try:
             cur.close()
@@ -199,23 +205,24 @@ def generate_questions_from_pdf():
 
     provider_name = prov_row[0] if prov_row else ""
     cert_name = cert_row[0] if cert_row else ""
+    domain_name = dom_row[0] if dom_row else ""
 
     # Distribution des questions
-    pairs = []  # (q_type, scenario, count)
+    pairs = []  # (q_type, scenario, scenario_illu, count)
     if use_distribution:
-        dist = DISTRIBUTION.get("medium", {})
+        dist = DISTRIBUTION.get(level, {})
         base_total = sum(sum(s.values()) for s in dist.values()) or 1
         scale = num_questions / base_total
         for qt, scen_dict in dist.items():
             for scen, base_count in scen_dict.items():
                 count = int(round(base_count * scale))
                 if count > 0:
-                    pairs.append([qt, scen, count])
-        total = sum(p[2] for p in pairs)
+                    pairs.append([qt, scen, "none", count])
+        total = sum(p[3] for p in pairs)
         if pairs and total != num_questions:
-            pairs[0][2] += num_questions - total
+            pairs[0][3] += num_questions - total
     else:
-        pairs.append([q_type, "no", num_questions])
+        pairs.append([q_type, scenario, scenario_illustration_type, num_questions])
 
     chunk_size = 4000
     chunks = [text[i:i + chunk_size] for i in range(0, len(text), chunk_size)] or [text]
@@ -223,23 +230,24 @@ def generate_questions_from_pdf():
     questions = []
     chunk_idx = 0
     num_chunks = len(chunks)
-    for qt, scen, count in pairs:
+    for qt, scen, scen_illu, count in pairs:
         remaining = count
         while remaining > 0:
             chunk = chunks[chunk_idx % num_chunks]
             chunk_idx += 1
             to_generate = min(remaining, 5)
             try:
-                data = ai_generate_questions(
+                data = generate_questions(
                     provider_name=provider_name,
                     certification=cert_name,
-                    domain="PDF content",
+                    domain=domain_name,
                     domain_descr=chunk,
-                    level="medium",
+                    level=level,
                     q_type=qt,
                     practical=scen,
-                    scenario_illustration_type="none",
+                    scenario_illustration_type=scen_illu,
                     num_questions=to_generate,
+                    use_text=True,
                 )
                 questions.extend(data.get("questions", []))
                 remaining -= len(data.get("questions", []))
@@ -252,7 +260,7 @@ def generate_questions_from_pdf():
                 }), 500
 
     session_id = os.urandom(8).hex()
-    SESSIONS[session_id] = {"module_id": module_id, "questions": questions}
+    SESSIONS[session_id] = {"domain_id": domain_id, "questions": questions}
     return jsonify({"status": "ok", "session_id": session_id, "json_data": {"questions": questions}})
 
 # -------------------- Upload / Analyse PDF --------------------
@@ -336,7 +344,7 @@ def import_questions():
                     INSERT INTO questions (text, level, descr, nature, ty, maxr, module)
                     VALUES (%s, %s, %s, %s, %s, %s, %s)
                     """,
-                    (question_text, q_level_code, None, q_nature_code, q_scenario_code, maxr, data["module_id"]),
+                    (question_text, q_level_code, None, q_nature_code, q_scenario_code, maxr, data["domain_id"]),
                 )
                 question_id = cur.lastrowid
                 q_imported += 1

--- a/templates/home.html
+++ b/templates/home.html
@@ -20,6 +20,7 @@
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('move.index') }}">Move Questions</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('reloc.index') }}">Relocate</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.index') }}">PDF Importer</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.generate_index') }}">PDF Generator</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('quest.index') }}">Manual Import</a></li>
 
       </ul>
@@ -47,6 +48,10 @@
       <a class="block p-6 bg-white rounded shadow hover:shadow-lg" href="{{ url_for('pdf.index') }}">
         <h2 class="text-xl font-semibold mb-2">PDF Importer</h2>
         <p class="text-gray-600">Extract questions directly from PDF files.</p>
+      </a>
+      <a class="block p-6 bg-white rounded shadow hover:shadow-lg" href="{{ url_for('pdf.generate_index') }}">
+        <h2 class="text-xl font-semibold mb-2">PDF Question Generator</h2>
+        <p class="text-gray-600">Use a PDF as source to generate new questions.</p>
       </a>
       <a class="block p-6 bg-white rounded shadow hover:shadow-lg" href="{{ url_for('quest.index') }}">
         <h2 class="text-xl font-semibold mb-2">Manual Question Import</h2>

--- a/templates/import_modules.html
+++ b/templates/import_modules.html
@@ -29,6 +29,7 @@
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('move.index') }}">Move Questions</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('reloc.index') }}">Relocate</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.index') }}">PDF Importer</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.generate_index') }}">PDF Generator</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('quest.index') }}">Manual Import</a></li>
       </ul>
     </div>

--- a/templates/import_questions.html
+++ b/templates/import_questions.html
@@ -28,6 +28,7 @@
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('move.index') }}">Move Questions</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('reloc.index') }}">Relocate</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.index') }}">PDF Importer</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.generate_index') }}">PDF Generator</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('quest.index') }}">Manual Import</a></li>
       </ul>
     </div>

--- a/templates/move_questions.html
+++ b/templates/move_questions.html
@@ -28,6 +28,7 @@
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('move.index') }}">Move Questions</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('reloc.index') }}">Relocate</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.index') }}">PDF Importer</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.generate_index') }}">PDF Generator</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('quest.index') }}">Manual Import</a></li>
       </ul>
     </div>

--- a/templates/pdf_generate.html
+++ b/templates/pdf_generate.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Generate Questions from PDF</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <style>
+    .brand-bg { background-color:#28a745; }
+    .brand-hover:hover { background-color:#218838; }
+    #loadingOverlay { position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.4); display:none; align-items:center; justify-content:center; z-index:50; }
+    #loadingOverlay.show { display:flex; }
+    .loader { border:8px solid #f3f3f3; border-top:8px solid #28a745; border-radius:50%; width:60px; height:60px; animation:spin 1s linear infinite; }
+    @keyframes spin { to { transform:rotate(360deg); } }
+  </style>
+</head>
+<body class="bg-gray-100">
+  <nav class="brand-bg text-white">
+    <div class="container mx-auto px-4 py-4 flex flex-wrap items-center justify-between">
+      <a href="{{ url_for('home') }}" class="text-2xl font-semibold">ExBoot Laboratory</a>
+      <ul class="flex flex-wrap space-x-4 mt-4 sm:mt-0">
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('populate_index') }}">Populate</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('dom.index') }}">Import Modules</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('move.index') }}">Move Questions</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('reloc.index') }}">Relocate</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.index') }}">PDF Importer</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.generate_index') }}">PDF Generator</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('quest.index') }}">Manual Import</a></li>
+      </ul>
+    </div>
+  </nav>
+  <main class="container mx-auto px-4 mt-8">
+    <div class="max-w-3xl mx-auto bg-white p-8 shadow rounded">
+      <h2 class="text-2xl font-bold text-center mb-4">🤖 Generate Questions from PDF</h2>
+      <form id="generateForm" class="space-y-4 mb-4" enctype="multipart/form-data">
+        <div>
+          <label class="font-bold block mb-1">Provider:</label>
+          <select name="provider_id" id="providerSelect" class="w-full border rounded p-2" required></select>
+        </div>
+        <div>
+          <label class="font-bold block mb-1">Certification:</label>
+          <select name="cert_id" id="certSelect" class="w-full border rounded p-2" required></select>
+        </div>
+        <div>
+          <label class="font-bold block mb-1">Module:</label>
+          <input type="text" id="moduleSearch" placeholder="Rechercher..." class="w-full border rounded p-2 mb-2">
+          <select name="module_id" id="moduleSelect" class="w-full border rounded p-2" required></select>
+        </div>
+        <div>
+          <label class="font-bold block mb-1">PDF File:</label>
+          <input type="file" name="pdf_file" id="pdfFile" accept="application/pdf" class="w-full" required>
+        </div>
+        <div>
+          <label class="font-bold block mb-1">Number of questions:</label>
+          <input type="number" name="num_questions" id="numQuestions" min="1" value="5" class="w-full border rounded p-2" required>
+        </div>
+        <div>
+          <label class="font-bold block mb-1">Question type:</label>
+          <select name="q_type" id="qType" class="w-full border rounded p-2">
+            <option value="qcm">QCM</option>
+            <option value="truefalse">True/False</option>
+            <option value="short-answer">Short Answer</option>
+            <option value="matching">Matching</option>
+            <option value="drag-n-drop">Drag & Drop</option>
+          </select>
+          <label class="inline-flex items-center mt-2"><input type="checkbox" id="useDistribution" name="use_distribution" class="mr-2">Appliquer la configuration de distribution</label>
+        </div>
+        <button type="submit" id="generateBtn" class="brand-bg text-white w-full py-2 rounded brand-hover">Générer les questions</button>
+      </form>
+      <div id="jsonContainer" class="hidden">
+        <h4 class="text-lg font-bold mb-2">📋 JSON généré</h4>
+        <textarea id="jsonPreview" class="w-full h-72 border rounded p-2 font-mono bg-gray-800 text-gray-100" readonly></textarea>
+        <button id="importBtn" class="brand-bg text-white w-full py-2 rounded mt-3 brand-hover">✅ Importer en BD</button>
+      </div>
+    </div>
+    <div id="loadingOverlay"><div class="loader"></div></div>
+  </main>
+<script>
+function option(text, value) {
+    const o = document.createElement("option");
+    o.textContent = text; o.value = value;
+    return o;
+}
+const base = '{{ url_for('pdf.index') }}';
+const genUrl = '{{ url_for('pdf.generate_questions_from_pdf') }}';
+let currentSession = null;
+
+// Providers -> Certifications -> Modules cascade (reuse from upload.html)
+fetch(base + "api/providers").then(r => r.json()).then(data => {
+    const providerSelect = document.getElementById("providerSelect");
+    providerSelect.innerHTML = "";
+    data.forEach(p => providerSelect.appendChild(option(p.name, p.id)));
+    if (data.length > 0) {
+        providerSelect.value = data[0].id;
+        providerSelect.dispatchEvent(new Event("change"));
+    }
+});
+
+document.getElementById("providerSelect").addEventListener("change", function(){
+    const prov_id = this.value;
+    const certSelect = document.getElementById("certSelect");
+    const modSelect = document.getElementById("moduleSelect");
+    certSelect.innerHTML = ""; modSelect.innerHTML = "";
+    if (!prov_id) return;
+    fetch(`${base}api/certifications/${prov_id}`).then(r=>r.json()).then(data=>{
+        data.forEach(c => certSelect.appendChild(option(c.name, c.id)));
+        if (data.length>0){ certSelect.value = data[0].id; certSelect.dispatchEvent(new Event("change")); }
+    });
+});
+
+document.getElementById("certSelect").addEventListener("change", function(){
+    const cert_id = this.value;
+    const modSelect = document.getElementById("moduleSelect");
+    modSelect.innerHTML = "";
+    if (!cert_id) return;
+    fetch(`${base}api/modules/${cert_id}`).then(r=>r.json()).then(data=>{
+        data.forEach(m => modSelect.appendChild(option(m.name, m.id)));
+    });
+});
+
+// Module search filter
+const modSearch = document.getElementById('moduleSearch');
+modSearch.addEventListener('input', function(){
+    const term = this.value.toLowerCase();
+    const sel = document.getElementById('moduleSelect');
+    Array.from(sel.options).forEach(o => { o.hidden = term && !o.text.toLowerCase().includes(term); });
+});
+
+// Toggle qType when distribution checkbox checked
+const useDist = document.getElementById('useDistribution');
+useDist.addEventListener('change', function(){
+    document.getElementById('qType').disabled = this.checked;
+});
+
+// Submit generation form
+document.getElementById("generateForm").addEventListener("submit", async function(e){
+    e.preventDefault();
+    const overlay = document.getElementById('loadingOverlay');
+    overlay.classList.add('show');
+    const formData = new FormData(this);
+    try {
+        const res = await fetch(genUrl, {method:'POST', body:formData});
+        const data = await res.json();
+        if (data.status === 'ok') {
+            currentSession = data.session_id;
+            document.getElementById('jsonPreview').value = JSON.stringify(data.json_data, null, 4);
+            document.getElementById('jsonContainer').classList.remove('hidden');
+        } else {
+            alert('Erreur: ' + (data.message || 'génération impossible'));
+        }
+    } catch(err){
+        alert('Erreur réseau');
+    } finally {
+        overlay.classList.remove('show');
+    }
+});
+
+// Import to DB
+ document.getElementById('importBtn').addEventListener('click', async function(){
+    if(!currentSession) return;
+    const form = new FormData();
+    form.append('session_id', currentSession);
+    const res = await fetch(base + 'import-questions', {method:'POST', body:form});
+    const data = await res.json();
+    alert(data.status === 'ok' ? 'Import réussi' : ('Erreur: ' + (data.message || 'import échoué')));
+ });
+</script>
+</body>
+</html>

--- a/templates/pdf_generate.html
+++ b/templates/pdf_generate.html
@@ -41,9 +41,9 @@
           <select name="cert_id" id="certSelect" class="w-full border rounded p-2" required></select>
         </div>
         <div>
-          <label class="font-bold block mb-1">Module:</label>
-          <input type="text" id="moduleSearch" placeholder="Rechercher..." class="w-full border rounded p-2 mb-2">
-          <select name="module_id" id="moduleSelect" class="w-full border rounded p-2" required></select>
+          <label class="font-bold block mb-1">Domain:</label>
+          <input type="text" id="domainSearch" placeholder="Rechercher..." class="w-full border rounded p-2 mb-2">
+          <select name="domain_id" id="domainSelect" class="w-full border rounded p-2" required></select>
         </div>
         <div>
           <label class="font-bold block mb-1">PDF File:</label>
@@ -52,6 +52,33 @@
         <div>
           <label class="font-bold block mb-1">Number of questions:</label>
           <input type="number" name="num_questions" id="numQuestions" min="1" value="5" class="w-full border rounded p-2" required>
+        </div>
+        <div>
+          <label class="font-bold block mb-1">Difficulty level:</label>
+          <select name="level" id="levelSelect" class="w-full border rounded p-2">
+            <option value="easy">Easy</option>
+            <option value="medium" selected>Medium</option>
+            <option value="hard">Hard</option>
+          </select>
+        </div>
+        <div>
+          <label class="font-bold block mb-1">Scenario type:</label>
+          <select name="scenario" id="scenarioSelect" class="w-full border rounded p-2">
+            <option value="no">No Scenario</option>
+            <option value="scenario">Scenario</option>
+            <option value="scenario-illustrated">Scenario Illustrated</option>
+          </select>
+        </div>
+        <div>
+          <label class="font-bold block mb-1">Scenario illustration:</label>
+          <select name="scenario_illustration_type" id="scenarioIllustration" class="w-full border rounded p-2" disabled>
+            <option value="none">None</option>
+            <option value="case">Case Study</option>
+            <option value="archi">Architecture</option>
+            <option value="config">Configuration</option>
+            <option value="console">Console</option>
+            <option value="code">Code</option>
+          </select>
         </div>
         <div>
           <label class="font-bold block mb-1">Question type:</label>
@@ -84,7 +111,7 @@ const base = '{{ url_for('pdf.index') }}';
 const genUrl = '{{ url_for('pdf.generate_questions_from_pdf') }}';
 let currentSession = null;
 
-// Providers -> Certifications -> Modules cascade (reuse from upload.html)
+// Providers -> Certifications -> Domains cascade
 fetch(base + "api/providers").then(r => r.json()).then(data => {
     const providerSelect = document.getElementById("providerSelect");
     providerSelect.innerHTML = "";
@@ -98,8 +125,8 @@ fetch(base + "api/providers").then(r => r.json()).then(data => {
 document.getElementById("providerSelect").addEventListener("change", function(){
     const prov_id = this.value;
     const certSelect = document.getElementById("certSelect");
-    const modSelect = document.getElementById("moduleSelect");
-    certSelect.innerHTML = ""; modSelect.innerHTML = "";
+    const domSelect = document.getElementById("domainSelect");
+    certSelect.innerHTML = ""; domSelect.innerHTML = "";
     if (!prov_id) return;
     fetch(`${base}api/certifications/${prov_id}`).then(r=>r.json()).then(data=>{
         data.forEach(c => certSelect.appendChild(option(c.name, c.id)));
@@ -109,26 +136,41 @@ document.getElementById("providerSelect").addEventListener("change", function(){
 
 document.getElementById("certSelect").addEventListener("change", function(){
     const cert_id = this.value;
-    const modSelect = document.getElementById("moduleSelect");
-    modSelect.innerHTML = "";
+    const domSelect = document.getElementById("domainSelect");
+    domSelect.innerHTML = "";
     if (!cert_id) return;
-    fetch(`${base}api/modules/${cert_id}`).then(r=>r.json()).then(data=>{
-        data.forEach(m => modSelect.appendChild(option(m.name, m.id)));
+    fetch(`${base}api/domains/${cert_id}`).then(r=>r.json()).then(data=>{
+        data.forEach(m => domSelect.appendChild(option(m.name, m.id)));
     });
 });
 
-// Module search filter
-const modSearch = document.getElementById('moduleSearch');
-modSearch.addEventListener('input', function(){
+// Domain search filter
+const domSearch = document.getElementById('domainSearch');
+domSearch.addEventListener('input', function(){
     const term = this.value.toLowerCase();
-    const sel = document.getElementById('moduleSelect');
+    const sel = document.getElementById('domainSelect');
     Array.from(sel.options).forEach(o => { o.hidden = term && !o.text.toLowerCase().includes(term); });
 });
 
-// Toggle qType when distribution checkbox checked
+// Toggle inputs when distribution checkbox checked
 const useDist = document.getElementById('useDistribution');
 useDist.addEventListener('change', function(){
     document.getElementById('qType').disabled = this.checked;
+    document.getElementById('levelSelect').disabled = this.checked;
+    document.getElementById('scenarioSelect').disabled = this.checked;
+    document.getElementById('scenarioIllustration').disabled = this.checked || document.getElementById('scenarioSelect').value === 'no';
+});
+
+// Enable/disable scenario illustration
+const scenarioSelect = document.getElementById('scenarioSelect');
+const scenIllu = document.getElementById('scenarioIllustration');
+scenarioSelect.addEventListener('change', function(){
+    if(this.value === 'no'){
+        scenIllu.value = 'none';
+        scenIllu.disabled = true;
+    } else {
+        scenIllu.disabled = useDist.checked ? true : false;
+    }
 });
 
 // Submit generation form

--- a/templates/populate.html
+++ b/templates/populate.html
@@ -22,6 +22,7 @@
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('move.index') }}">Move Questions</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('reloc.index') }}">Relocate</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.index') }}">PDF Importer</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.generate_index') }}">PDF Generator</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('quest.index') }}">Manual Import</a></li>
       </ul>
     </div>

--- a/templates/reloc.html
+++ b/templates/reloc.html
@@ -30,6 +30,7 @@
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('move.index') }}">Move Questions</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('reloc.index') }}">Relocate</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.index') }}">PDF Importer</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.generate_index') }}">PDF Generator</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('quest.index') }}">Manual Import</a></li>
       </ul>
     </div>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -26,6 +26,7 @@
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('move.index') }}">Move Questions</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('reloc.index') }}">Relocate</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.index') }}">PDF Importer</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.generate_index') }}">PDF Generator</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('quest.index') }}">Manual Import</a></li>
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- Add OpenAI-powered question generator that creates questions from uploaded PDF sections
- Provide web form to choose provider, certification, module, question count and type or use distribution
- Integrate new PDF Generator menu and navigation across templates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5fdfcf5588325a777e8b1db9f7016