### PR TITLE
Validate file paths for PDF uploads

### DIFF
--- a/tests/test_upload_pdf.py
+++ b/tests/test_upload_pdf.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import app
+
+class UploadPdfPathValidationTest(unittest.TestCase):
+    def test_rejects_disallowed_file_path(self):
+        with app.app.test_client() as client, \
+             patch('pdf_importer.extract_text_from_pdf', return_value=''), \
+             patch('pdf_importer.detect_questions', return_value={}):
+            resp = client.post('/pdf/upload-pdf', data={'module_id': '1', 'file_path': '/etc/passwd'})
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(resp.json.get('status'), 'error')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Restrict `file_path` to the server upload directory and resolve paths securely
- Add regression test ensuring outside paths are rejected

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b657984ec48325a0a2eecde01ee5f3