### PR TITLE
Auto-select defaults and resilient question relocation

### DIFF
--- a/reloc.py
+++ b/reloc.py
@@ -44,6 +44,17 @@ def api_modules(cert_id):
     cur.close(); conn.close()
     return json.dumps(rows, ensure_ascii=False), 200, {'Content-Type':'application/json'}
 
+
+@reloc_bp.route('/api/question_count/<int:module_id>')
+def api_question_count(module_id):
+    """Retourne le nombre de questions restantes dans un module."""
+    conn = mysql.connector.connect(**DB_CONFIG)
+    cur = conn.cursor()
+    cur.execute("SELECT COUNT(*) FROM questions WHERE module = %s", (module_id,))
+    count = cur.fetchone()[0]
+    cur.close(); conn.close()
+    return json.dumps({'count': count}, ensure_ascii=False), 200, {'Content-Type': 'application/json'}
+
 # -- SSE pour le streaming de la relocalisation --
 @reloc_bp.route('/api/stream_relocate', methods=['GET'])
 def stream_relocate():
@@ -57,22 +68,20 @@ def stream_relocate():
     def generate():
         # 1) Charger la liste des modules de destination (une seule fois)
         conn0 = mysql.connector.connect(**DB_CONFIG)
-        cur0  = conn0.cursor(dictionary=True)
+        cur0 = conn0.cursor(dictionary=True)
         cur0.execute("SELECT id, name FROM modules WHERE course = %s", (dst_cert,))
         modules = cur0.fetchall()
         cur0.close(); conn0.close()
 
-        offset = 0
         total_moved = 0
 
         while True:
-            # 2) Récupérer un batch de questions
+            # 2) Récupérer un batch de questions (toujours les premières restantes)
             conn1 = mysql.connector.connect(**DB_CONFIG)
-            cur1  = conn1.cursor(dictionary=True)
+            cur1 = conn1.cursor(dictionary=True)
             cur1.execute(
-                "SELECT id, text FROM questions WHERE module = %s "
-                "LIMIT %s OFFSET %s",
-                (src_module, batch_size, offset)
+                "SELECT id, text FROM questions WHERE module = %s LIMIT %s",
+                (src_module, batch_size)
             )
             questions = cur1.fetchall()
             cur1.close(); conn1.close()
@@ -150,10 +159,11 @@ def stream_relocate():
             conn2.close()
 
             total_moved += moved
-            offset += batch_size
 
             # 7) Envoi de l’événement SSE pour ce batch
-            yield f"data: Batch offset={offset}, moved={moved}, total={total_moved}\n\n"
+            yield f"data: Batch moved={moved}, total={total_moved}\n\n"
+            if moved == 0:
+                break
             sleep(0.1)
 
         # 8) Fin du flux

--- a/templates/reloc.html
+++ b/templates/reloc.html
@@ -73,12 +73,6 @@ async function initPanel(pref, hasModule, defProv=null, defCert=null){
   const s = hasModule && document.getElementById(pref+'-mod-search');
 
   const base = '{{ url_for('reloc.index') }}';
-
-  const provs = await loadJSON(base + 'api/providers');
-  fill(p, provs);
-  p.value = provs.find(x=>x.id===defProv)?.id || provs[0]?.id;
-  p.dispatchEvent(new Event('change'));
-
   p.addEventListener('change', async()=>{
     const cs = await loadJSON(`${base}api/certifications/${p.value}`);
     fill(c, cs);
@@ -91,59 +85,88 @@ async function initPanel(pref, hasModule, defProv=null, defCert=null){
     c.dispatchEvent(new Event('change'));
   });
 
-  if(!m) return;
-
-  s.addEventListener('input', function(){
-    const term = this.value.toLowerCase();
-    Array.from(m.options).forEach(o=>{
-      o.style.display = o.text.toLowerCase().includes(term) ? '' : 'none';
+  if(hasModule){
+    s.addEventListener('input', function(){
+      const term = this.value.toLowerCase();
+      Array.from(m.options).forEach(o=>{
+        o.style.display = o.text.toLowerCase().includes(term) ? '' : 'none';
+      });
     });
-  });
 
-  c.addEventListener('change', async()=>{
-    const ms = await loadJSON(`${base}api/modules/${c.value}`);
-    fill(m, ms);
-    s.value='';
-    s.dispatchEvent(new Event('input'));
-  });
+    c.addEventListener('change', async()=>{
+      const ms = await loadJSON(`${base}api/modules/${c.value}`);
+      fill(m, ms);
+      s.value='';
+      s.dispatchEvent(new Event('input'));
+    });
+  }
+
+  const provs = await loadJSON(base + 'api/providers');
+  fill(p, provs);
+  p.value = provs.find(x=>x.id===defProv)?.id || provs[0]?.id;
+  p.dispatchEvent(new Event('change'));
 }
 
 document.addEventListener('DOMContentLoaded', ()=>{
   initPanel('src', true, 169, 23);
-  initPanel('dst', false);
+  initPanel('dst', false, 169, 23);
 
-  document.getElementById('reloc-btn').onclick = ()=>{
-    const srcMod  = +document.getElementById('src-mod').value;
-    const dstCert = +document.getElementById('dst-cert').value;
-    if(!srcMod || !dstCert) return alert('Sélection manquante');
+  const base = '{{ url_for('reloc.index') }}';
+  const bar  = document.getElementById('bar');
+  const log  = document.getElementById('log');
 
+  async function checkAndRestart(srcMod, dstCert){
+    try{
+      const res = await fetch(`${base}api/question_count/${srcMod}`);
+      const {count} = await res.json();
+      if(count > 0){
+        log.textContent += `Relance automatique - questions restantes: ${count}\n`;
+        startReloc(srcMod, dstCert);
+      } else {
+        log.textContent += 'Relocalisation terminée\n';
+        bar.style.width = '100%';
+      }
+    }catch(e){
+      log.textContent += 'Erreur lors de la vérification du nombre de questions\n';
+    }
+  }
+
+  function startReloc(srcMod, dstCert){
     const params = new URLSearchParams({
       source_module_id:    srcMod,
       destination_cert_id: dstCert,
       batch_size:          10
     });
-    const base = '{{ url_for('reloc.index') }}';
+
     const evt = new EventSource(`${base}api/stream_relocate?${params}`);
-    const bar = document.getElementById('bar'),
-          log = document.getElementById('log');
     let batches = 0;
 
     evt.onmessage = e => {
       log.textContent += e.data + "\n";
-      if(e.data.startsWith('Batch offset')) {
+      if(e.data.startsWith('Batch')){
         batches++;
-        // Si vous connaissez le nombre total de batches, adaptez ici le %
         bar.style.width = Math.min(100, batches*10)+'%';
       }
-      if(e.data.startsWith('DONE') || e.data.startsWith('Aucun')) {
-        bar.style.width = '100%';
+      if(e.data.startsWith('DONE') || e.data.startsWith('Aucun')){
         evt.close();
+        checkAndRestart(srcMod, dstCert);
       }
     };
+
     evt.onerror = () => {
       log.textContent += 'Erreur de connexion SSE\n';
       evt.close();
+      checkAndRestart(srcMod, dstCert);
     };
+  }
+
+  document.getElementById('reloc-btn').onclick = ()=>{
+    const srcMod  = +document.getElementById('src-mod').value;
+    const dstCert = +document.getElementById('dst-cert').value;
+    if(!srcMod || !dstCert) return alert('Sélection manquante');
+    bar.style.width = '0%';
+    log.textContent = '';
+    startReloc(srcMod, dstCert);
   };
 });
 </script>


### PR DESCRIPTION
## Summary
- Default provider and certification are preselected in the relocation UI
- Added API endpoint and refactored relocation stream to process all questions
- Client retries relocation automatically until no questions remain
- Stop relocation loop when a batch moves no questions to avoid infinite retries

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7739a950883258626bb7d66b76fae