### PR TITLE
feat: real-time populate progress

### DIFF
--- a/populate.html
+++ b/populate.html
@@ -93,36 +93,44 @@
             }, "json");
         });
         
-        // Lancement du processus de population et mise à jour dynamique des logs et compteurs
+        // Lancement du processus de population et suivi temps réel
+        let poller = null;
+        let lastLogIndex = 0;
+        function fetchStatus(){
+            $.get("/populate/status", function(resp){
+                if(resp.log){
+                    for(; lastLogIndex < resp.log.length; lastLogIndex++){
+                        $("#logList").append("<li>" + resp.log[lastLogIndex] + "</li>");
+                    }
+                }
+                if(resp.counters){
+                    $("#analysisResult").text(resp.counters.analysis);
+                    $("#domainCounter").text(resp.counters.domainsProcessed + " / " + resp.counters.totalDomains);
+                    $("#questionCounter").text(resp.counters.totalQuestions);
+                    var percent = 0;
+                    if(resp.counters.totalDomains){
+                        percent = Math.round((resp.counters.domainsProcessed / resp.counters.totalDomains) * 100);
+                    }
+                    $("#progressBarFill").css("width", percent + "%").text(percent + "%");
+                }
+                if(resp.status === "completed" || resp.status === "error"){
+                    clearInterval(poller);
+                }
+            }, "json");
+        }
+
         $("#startPopulate").click(function(){
             $("#logList").empty();
             $("#progressBarFill").css("width", "0%").text("0%");
-            // Réinitialiser les compteurs affichés
             $("#analysisResult").text("En attente...");
             $("#domainCounter").text("0 / 0");
             $("#questionCounter").text("0");
+            lastLogIndex = 0;
             $.post("/populate/process", {
                 provider_id: "{{ provider_id }}",
                 cert_id: "{{ cert_id }}"
-            }, function(response){
-                var logs = response.log;
-                var total = logs.length;
-                var i = 0;
-                if(response.counters) {
-                    $("#analysisResult").text(response.counters.analysis);
-                    $("#domainCounter").text(response.counters.domainsProcessed + " / " + response.counters.totalDomains);
-                    $("#questionCounter").text(response.counters.totalQuestions);
-                }
-                function displayNextLog() {
-                    if (i < total) {
-                        $("#logList").append("<li>" + logs[i] + "</li>");
-                        var percent = Math.round(((i+1) / total) * 100);
-                        $("#progressBarFill").css("width", percent + "%").text(percent + "%");
-                        i++;
-                        setTimeout(displayNextLog, 500);
-                    }
-                }
-                displayNextLog();
+            }, function(){
+                poller = setInterval(fetchStatus, 1000);
             }, "json");
         });
 

--- a/templates/populate.html
+++ b/templates/populate.html
@@ -104,58 +104,67 @@
         $("#provider_id").change(function(){
             $.post("{{ url_for('get_certifications') }}", { provider_id: $(this).val() }, function(data){
                 $("#cert_id").empty();
-                $.each(data, function(i, item){
-                    $("#cert_id").append($("<option>", { 
+                $.each(data || [], function(i, item){
+                    $("#cert_id").append($("<option>", {
                         value: item.id,
-                        text : item.name 
+                        text : item.name
                     }));
                 });
             }, "json");
         });
-        
-        // Lancement du processus de population et mise à jour dynamique des logs et compteurs
+
+        // Lancement du processus de population et suivi temps réel
+        let poller = null;
+        let lastLogIndex = 0;
+
+        function fetchStatus(){
+            $.get("{{ url_for('populate_status') }}", function(resp){
+                if(resp && resp.log){
+                    for(; lastLogIndex < resp.log.length; lastLogIndex++){
+                        $("#logList").append("<li>" + resp.log[lastLogIndex] + "</li>");
+                    }
+                }
+                if(resp && resp.counters){
+                    $("#analysisResult").text(resp.counters.analysis);
+                    $("#domainCounter").text(resp.counters.domainsProcessed + " / " + resp.counters.totalDomains);
+                    $("#questionCounter").text(resp.counters.totalQuestions);
+                    var percent = 0;
+                    if(resp.counters.totalDomains){
+                        percent = Math.round((resp.counters.domainsProcessed / resp.counters.totalDomains) * 100);
+                    }
+                    $("#progressBarFill").css("width", percent + "%").text(percent + "%");
+                }
+                if(resp && (resp.status === "completed" || resp.status === "error")){
+                    clearInterval(poller);
+                }
+            }, "json");
+        }
+
         $("#startPopulate").click(function(){
             $("#logList").empty();
             $("#progressBarFill").css("width", "0%").text("0%");
-            // Réinitialiser les compteurs affichés
             $("#analysisResult").text("En attente...");
             $("#domainCounter").text("0 / 0");
             $("#questionCounter").text("0");
+            lastLogIndex = 0;
             $.post("{{ url_for('populate_process') }}", {
                 provider_id: "{{ provider_id }}",
                 cert_id: "{{ cert_id }}"
-            }, function(response){
-                var logs = response.log;
-                var total = logs.length;
-                var i = 0;
-                if(response.counters) {
-                    $("#analysisResult").text(response.counters.analysis);
-                    $("#domainCounter").text(response.counters.domainsProcessed + " / " + response.counters.totalDomains);
-                    $("#questionCounter").text(response.counters.totalQuestions);
-                }
-                function displayNextLog() {
-                    if (i < total) {
-                        $("#logList").append("<li>" + logs[i] + "</li>");
-                        var percent = Math.round(((i+1) / total) * 100);
-                        $("#progressBarFill").css("width", percent + "%").text(percent + "%");
-                        i++;
-                        setTimeout(displayNextLog, 500);
-                    }
-                }
-                displayNextLog();
+            }, function(){
+                poller = setInterval(fetchStatus, 1000);
             }, "json");
         });
 
         // Bouton de pause
         $("#pausePopulate").click(function(){
-            $.post("{{ url_for('pause_populate') }}", {}, function(response){
+            $.post("{{ url_for('pause_populate') }}", {}, function(){
                 $("#logList").append("<li>Processus mis en pause.</li>");
             }, "json");
         });
 
         // Bouton de reprise
         $("#resumePopulate").click(function(){
-            $.post("{{ url_for('resume_populate') }}", {}, function(response){
+            $.post("{{ url_for('resume_populate') }}", {}, function(){
                 $("#logList").append("<li>Processus repris.</li>");
             }, "json");
         });


### PR DESCRIPTION
## Summary
- track populate progress on server via shared state and new status endpoint
- poll status from frontend to render real-time progress bar and logs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b771ad3da88325a8e620a269160b61