### PR TITLE
Add password-protected GUI to control local web service

### DIFF
--- a/config.py
+++ b/config.py
@@ -38,6 +38,14 @@ OPENAI_MAX_RETRIES = int(os.environ.get("OPENAI_MAX_RETRIES", "5"))
 API_REQUEST_DELAY = float(os.environ.get("API_REQUEST_DELAY", "1"))
 
 # ---------------------------------------------------------------------------
+# GUI authentication
+# ---------------------------------------------------------------------------
+# Password required by the local GUI before the web service can be started.
+# It defaults to ``admin`` but can be overridden via the ``GUI_PASSWORD``
+# environment variable to avoid hard-coding sensitive values in the codebase.
+GUI_PASSWORD = os.environ.get("GUI_PASSWORD", "admin")
+
+# ---------------------------------------------------------------------------
 # Question distribution
 # ---------------------------------------------------------------------------
 # ``DISTRIBUTION`` defines how many questions must be generated for each


### PR DESCRIPTION
## Summary
- add configurable GUI password setting
- implement Tkinter GUI to start/stop the Flask app after authentication

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7c05a12d483259c9aef658fa73a1a