### PR TITLE
Fix PDF answer extraction and duplicate handling

### DIFF
--- a/pdf_importer.py
+++ b/pdf_importer.py
@@ -323,16 +323,8 @@ def import_questions():
     questions = data.get("questions", [])
     future = db.execute_async(db.insert_questions, module_id, {"questions": questions}, "no")
     try:
-        future.result()
+        stats = future.result()
     except Exception as e:
         return jsonify({"status": "error", "message": str(e)}), 500
 
-    q_count = len(questions)
-    ans_count = sum(len(q.get("answers") or []) for q in questions)
-    return jsonify({
-        "status": "ok",
-        "imported_questions": q_count,
-        "skipped_questions": 0,
-        "imported_answers": ans_count,
-        "reused_answers": 0,
-    })
+    return jsonify({"status": "ok", **stats})

--- a/tests/test_detect_questions.py
+++ b/tests/test_detect_questions.py
@@ -1,0 +1,32 @@
+import unittest
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import routes_pdf
+
+class DetectQuestionsCorrectAnswerTest(unittest.TestCase):
+    def test_correct_answers_marked(self):
+        text = (
+            "NEW QUESTION 1\n"
+            "What are even numbers?\n"
+            "A. 1\n"
+            "B. 2\n"
+            "C. 3\n"
+            "D. 4\n"
+            "Answer: B,D\n"
+            "\n"
+            "NEW QUESTION 2\n"
+            "Sky is blue.\n"
+            "Answer: True\n"
+        )
+        data = routes_pdf.detect_questions(text, module_id=1)
+        self.assertEqual(len(data['questions']), 2)
+        q1 = data['questions'][0]
+        isoks = [a['isok'] for a in q1['answers']]
+        self.assertEqual(isoks, [0,1,0,1])
+        q2 = data['questions'][1]
+        self.assertEqual(q2['nature'], 'truefalse')
+        self.assertEqual([a['isok'] for a in q2['answers']], [1,0])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_insert_questions.py
+++ b/tests/test_insert_questions.py
@@ -1,0 +1,95 @@
+import unittest
+from unittest.mock import patch
+import json
+import db
+import mysql.connector
+
+class FakeCursor:
+    def __init__(self):
+        self.lastrowid = 0
+        self.questions = set()
+        self.answers = {}
+        self._select_res = None
+    def execute(self, query, params):
+        q = query.strip()
+        if q.startswith("INSERT INTO questions"):
+            text = params[0]
+            if text in self.questions:
+                raise mysql.connector.errors.IntegrityError(msg="dup", errno=1062, sqlstate="23000")
+            self.questions.add(text)
+            self.lastrowid = len(self.questions)
+        elif q.startswith("INSERT INTO answers"):
+            text = params[0]
+            if text in self.answers:
+                raise mysql.connector.errors.IntegrityError(msg="dup", errno=1062, sqlstate="23000")
+            ans_id = len(self.answers) + 1
+            self.answers[text] = ans_id
+            self.lastrowid = ans_id
+        elif q.startswith("SELECT id FROM answers"):
+            ans_id = self.answers.get(params[0])
+            self._select_res = (ans_id,)
+        elif q.startswith("INSERT INTO quest_ans"):
+            pass
+        else:
+            raise NotImplementedError(query)
+    def fetchone(self):
+        return self._select_res
+    def close(self):
+        pass
+
+class FakeConnection:
+    def __init__(self):
+        self.cursor_obj = FakeCursor()
+    def cursor(self):
+        return self.cursor_obj
+    def commit(self):
+        pass
+    def rollback(self):
+        pass
+    def close(self):
+        pass
+
+class InsertQuestionsDedupTest(unittest.TestCase):
+    def test_skip_and_reuse(self):
+        questions_json = {
+            "questions": [
+                {
+                    "text": "Q1",
+                    "level": "medium",
+                    "nature": "qcm",
+                    "answers": [
+                        {"value": "A1", "isok": 1},
+                        {"value": "A2"}
+                    ]
+                },
+                {
+                    "text": "Q2",
+                    "level": "medium",
+                    "nature": "qcm",
+                    "answers": [
+                        {"value": "A1"},
+                        {"value": "A3"}
+                    ]
+                },
+                {
+                    "text": "Q1",
+                    "level": "medium",
+                    "nature": "qcm",
+                    "answers": [
+                        {"value": "A4"},
+                        {"value": "A5"}
+                    ]
+                }
+            ]
+        }
+
+        with patch('db.get_connection', return_value=FakeConnection()):
+            stats = db.insert_questions(1, questions_json, "no")
+
+        self.assertEqual(stats['imported_questions'], 2)
+        self.assertEqual(stats['skipped_questions'], 1)
+        self.assertEqual(stats['imported_answers'], 3)
+        self.assertEqual(stats['reused_answers'], 1)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- Parse `Answer:` lines to mark correct options in extracted questions
- Track skipped questions and reused answers when importing into DB
- Expose insertion statistics and add regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6dafe6b30832596dea16dd061a957