### PR TITLE
Add reports dashboard with aggregated question metrics

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,6 +64,30 @@ def pick_secondary_domains(all_domains, primary_domain):
 def home():
     return render_template("home.html")
 
+
+@app.route("/reports")
+def reports():
+    certification_id = 23
+
+    futures = {
+        "domain_counts": db.execute_async(db.get_domain_question_counts_for_cert, certification_id),
+        "missing_correct": db.execute_async(db.get_certifications_missing_correct_answers),
+        "missing_answers": db.execute_async(db.get_domains_missing_answers_by_type),
+    }
+
+    domain_counts = futures["domain_counts"].result()
+    missing_correct = futures["missing_correct"].result()
+    missing_answers = futures["missing_answers"].result()
+
+    return render_template(
+        "reports.html",
+        certification_id=certification_id,
+        domain_counts=domain_counts,
+        missing_correct=missing_correct,
+        missing_answers=missing_answers,
+    )
+
+
 @app.route("/populate", methods=["GET", "POST"])
 def populate_index():
     if request.method == "POST":

--- a/db.py
+++ b/db.py
@@ -61,6 +61,103 @@ def get_domains_by_certification(cert_id):
     return domains
 
 
+def get_domain_question_counts_for_cert(cert_id):
+    """Return question counts per domain for a certification."""
+    conn = get_connection()
+    cursor = conn.cursor()
+    query = """
+        SELECT m.id, m.name, COUNT(q.id) AS total_questions
+        FROM modules m
+        LEFT JOIN questions q ON q.module = m.id
+        WHERE m.course = %s
+        GROUP BY m.id, m.name
+        ORDER BY m.name
+    """
+    cursor.execute(query, (cert_id,))
+    rows = cursor.fetchall()
+    cursor.close()
+    conn.close()
+    return [
+        {"id": row[0], "name": row[1], "total_questions": int(row[2] or 0)}
+        for row in rows
+    ]
+
+
+def get_certifications_missing_correct_answers():
+    """Return certifications that still miss correct answers on questions."""
+    conn = get_connection()
+    cursor = conn.cursor()
+    query = """
+        SELECT c.id, c.name, COUNT(DISTINCT q.id) AS missing_questions
+        FROM courses c
+        JOIN modules m ON m.course = c.id
+        JOIN questions q ON q.module = m.id
+        WHERE NOT EXISTS (
+            SELECT 1 FROM quest_ans qa WHERE qa.question = q.id AND qa.isok = 1
+        )
+        GROUP BY c.id, c.name
+        HAVING missing_questions > 0
+        ORDER BY missing_questions DESC, c.name
+    """
+    cursor.execute(query)
+    rows = cursor.fetchall()
+    cursor.close()
+    conn.close()
+    return [
+        {"id": row[0], "name": row[1], "missing_questions": int(row[2] or 0)}
+        for row in rows
+    ]
+
+
+def get_domains_missing_answers_by_type():
+    """Return domains with counts of questions missing answers grouped by type."""
+    conn = get_connection()
+    cursor = conn.cursor()
+    query = """
+        SELECT m.id, m.name, q.nature, COUNT(*) AS missing_count
+        FROM modules m
+        JOIN questions q ON q.module = m.id
+        WHERE NOT EXISTS (
+            SELECT 1 FROM quest_ans qa WHERE qa.question = q.id
+        )
+          AND q.nature IN (%s, %s, %s)
+        GROUP BY m.id, m.name, q.nature
+        ORDER BY m.name
+    """
+    cursor.execute(query, (
+        nature_mapping['qcm'],
+        nature_mapping['matching'],
+        nature_mapping['drag-n-drop'],
+    ))
+    rows = cursor.fetchall()
+    cursor.close()
+    conn.close()
+
+    results = {}
+    for domain_id, domain_name, nature_code, missing_count in rows:
+        domain_entry = results.setdefault(
+            domain_id,
+            {
+                "id": domain_id,
+                "name": domain_name,
+                "counts": {"qcm": 0, "matching": 0, "drag-n-drop": 0},
+            },
+        )
+        if nature_code == nature_mapping['qcm']:
+            key = 'qcm'
+        elif nature_code == nature_mapping['matching']:
+            key = 'matching'
+        else:
+            key = 'drag-n-drop'
+        domain_entry['counts'][key] += int(missing_count or 0)
+
+    for domain_entry in results.values():
+        domain_entry['total'] = sum(domain_entry['counts'].values())
+
+    # Sort domains by name for consistent display
+    return sorted(results.values(), key=lambda d: d['name'])
+
+
 def count_total_questions(domain_id):
     """
     Renvoie le nombre total de questions dans le domaine (module) donné.

--- a/templates/fix.html
+++ b/templates/fix.html
@@ -23,6 +23,7 @@
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.generate_index') }}">PDF Generator</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('quest.index') }}">Manual Import</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('fix_index') }}">Fix Questions</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('reports') }}">Reports</a></li>
       </ul>
     </div>
   </nav>

--- a/templates/home.html
+++ b/templates/home.html
@@ -23,6 +23,7 @@
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.generate_index') }}">PDF Generator</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('quest.index') }}">Manual Import</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('fix_index') }}">Fix Questions</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('reports') }}">Reports</a></li>
 
       </ul>
     </div>

--- a/templates/import_modules.html
+++ b/templates/import_modules.html
@@ -31,6 +31,7 @@
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.index') }}">PDF Importer</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.generate_index') }}">PDF Generator</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('quest.index') }}">Manual Import</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('reports') }}">Reports</a></li>
       </ul>
     </div>
   </nav>

--- a/templates/import_questions.html
+++ b/templates/import_questions.html
@@ -30,6 +30,7 @@
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.index') }}">PDF Importer</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.generate_index') }}">PDF Generator</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('quest.index') }}">Manual Import</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('reports') }}">Reports</a></li>
       </ul>
     </div>
   </nav>

--- a/templates/move_questions.html
+++ b/templates/move_questions.html
@@ -30,6 +30,7 @@
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.index') }}">PDF Importer</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.generate_index') }}">PDF Generator</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('quest.index') }}">Manual Import</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('reports') }}">Reports</a></li>
       </ul>
     </div>
   </nav>

--- a/templates/pdf_generate.html
+++ b/templates/pdf_generate.html
@@ -25,6 +25,7 @@
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.index') }}">PDF Importer</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.generate_index') }}">PDF Generator</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('quest.index') }}">Manual Import</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('reports') }}">Reports</a></li>
       </ul>
     </div>
   </nav>

--- a/templates/populate.html
+++ b/templates/populate.html
@@ -24,6 +24,7 @@
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.index') }}">PDF Importer</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.generate_index') }}">PDF Generator</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('quest.index') }}">Manual Import</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('reports') }}">Reports</a></li>
       </ul>
     </div>
   </nav>

--- a/templates/reloc.html
+++ b/templates/reloc.html
@@ -32,6 +32,7 @@
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.index') }}">PDF Importer</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.generate_index') }}">PDF Generator</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('quest.index') }}">Manual Import</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('reports') }}">Reports</a></li>
       </ul>
     </div>
   </nav>

--- a/templates/reports.html
+++ b/templates/reports.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <title>Reports - ExBoot Laboratory</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <style>
+    .brand-bg { background-color:#28a745; }
+    .brand-hover:hover { background-color:#218838; }
+    .card { transition: box-shadow 0.2s ease; }
+    .card:hover { box-shadow: 0 10px 25px rgba(0,0,0,0.1); }
+    .chevron { transition: transform 0.2s ease; }
+    .collapsed .chevron { transform: rotate(-90deg); }
+  </style>
+</head>
+<body class="bg-gray-100 min-h-screen">
+  <nav class="brand-bg text-white">
+    <div class="container mx-auto px-4 py-4 flex flex-wrap items-center justify-between">
+      <a href="{{ url_for('home') }}" class="text-2xl font-semibold">ExBoot Laboratory</a>
+      <ul class="flex flex-wrap space-x-4 mt-4 sm:mt-0">
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('populate_index') }}">Populate</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('dom.index') }}">Import Modules</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('move.index') }}">Move Questions</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('reloc.index') }}">Relocate</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.index') }}">PDF Importer</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.generate_index') }}">PDF Generator</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('quest.index') }}">Manual Import</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('fix_index') }}">Fix Questions</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('reports') }}">Reports</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <main class="container mx-auto px-4 py-10 space-y-6">
+    <header class="text-center">
+      <h1 class="text-4xl font-bold mb-2">Rapports clés</h1>
+      <p class="text-gray-600">Suivez l'état des questions en un clin d'œil. Les données sont chargées en parallèle pour garantir une navigation fluide.</p>
+    </header>
+
+    <section class="bg-white rounded-lg shadow card" data-collapsible>
+      <button type="button" class="w-full flex items-center justify-between px-6 py-4 text-left font-semibold text-lg focus:outline-none">
+        <span>Questions par domaine &mdash; Certification {{ certification_id }}</span>
+        <svg class="chevron w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      <div class="px-6 pb-6 hidden" data-content>
+        {% if domain_counts %}
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Domaine</th>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Nombre de questions</th>
+                </tr>
+              </thead>
+              <tbody class="bg-white divide-y divide-gray-200">
+                {% for domain in domain_counts %}
+                <tr>
+                  <td class="px-4 py-2 text-sm text-gray-700">{{ domain.name }}</td>
+                  <td class="px-4 py-2 text-sm text-gray-900 font-semibold">{{ domain.total_questions }}</td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        {% else %}
+          <p class="text-gray-600">Aucune question trouvée pour cette certification.</p>
+        {% endif %}
+      </div>
+    </section>
+
+    <section class="bg-white rounded-lg shadow card" data-collapsible>
+      <button type="button" class="w-full flex items-center justify-between px-6 py-4 text-left font-semibold text-lg focus:outline-none">
+        <span>Certifications avec questions sans réponse correcte</span>
+        <svg class="chevron w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      <div class="px-6 pb-6 hidden" data-content>
+        {% if missing_correct %}
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Certification</th>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Questions sans réponse correcte</th>
+                </tr>
+              </thead>
+              <tbody class="bg-white divide-y divide-gray-200">
+                {% for cert in missing_correct %}
+                <tr>
+                  <td class="px-4 py-2 text-sm text-gray-700">{{ cert.name }}</td>
+                  <td class="px-4 py-2 text-sm text-gray-900 font-semibold">{{ cert.missing_questions }}</td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        {% else %}
+          <p class="text-gray-600">Toutes les certifications disposent d'au moins une réponse correcte par question.</p>
+        {% endif %}
+      </div>
+    </section>
+
+    <section class="bg-white rounded-lg shadow card" data-collapsible>
+      <button type="button" class="w-full flex items-center justify-between px-6 py-4 text-left font-semibold text-lg focus:outline-none">
+        <span>Questions sans réponses par domaine et type</span>
+        <svg class="chevron w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+      <div class="px-6 pb-6 hidden" data-content>
+        {% if missing_answers %}
+          {% set type_labels = {"qcm": "QCM", "drag-n-drop": "Drag & Drop", "matching": "Matching"} %}
+          <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200">
+              <thead class="bg-gray-50">
+                <tr>
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Domaine</th>
+                  {% for key, label in type_labels.items() %}
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">{{ label }}</th>
+                  {% endfor %}
+                  <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Total</th>
+                </tr>
+              </thead>
+              <tbody class="bg-white divide-y divide-gray-200">
+                {% for domain in missing_answers %}
+                <tr>
+                  <td class="px-4 py-2 text-sm text-gray-700">{{ domain.name }}</td>
+                  {% for key, label in type_labels.items() %}
+                  <td class="px-4 py-2 text-sm text-gray-900">{{ domain.counts[key] }}</td>
+                  {% endfor %}
+                  <td class="px-4 py-2 text-sm font-semibold text-gray-900">{{ domain.total }}</td>
+                </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        {% else %}
+          <p class="text-gray-600">Toutes les questions disposent déjà d'au moins une réponse.</p>
+        {% endif %}
+      </div>
+    </section>
+  </main>
+
+  <script>
+    document.querySelectorAll('[data-collapsible]').forEach(function(card) {
+      const button = card.querySelector('button');
+      const content = card.querySelector('[data-content]');
+      if (!button || !content) return;
+
+      button.addEventListener('click', function() {
+        document.querySelectorAll('[data-collapsible] [data-content]').forEach(function(otherContent) {
+          if (otherContent !== content) {
+            otherContent.classList.add('hidden');
+            otherContent.parentElement.classList.add('collapsed');
+          }
+        });
+        content.classList.toggle('hidden');
+        card.classList.toggle('collapsed', content.classList.contains('hidden'));
+      });
+
+      card.classList.add('collapsed');
+    });
+  </script>
+</body>
+</html>

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -28,6 +28,7 @@
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.index') }}">PDF Importer</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('pdf.generate_index') }}">PDF Generator</a></li>
         <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('quest.index') }}">Manual Import</a></li>
+        <li><a class="px-3 py-2 rounded brand-hover" href="{{ url_for('reports') }}">Reports</a></li>
       </ul>
     </div>
   </nav>


### PR DESCRIPTION
## Summary
- add a /reports endpoint that preloads reporting data concurrently for fast rendering
- expose new database helpers to aggregate question counts for certification 23 and missing answer scenarios
- create a collapsible reports dashboard and add its link to the global navigation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce9a48ce7083258c6b269e849f50e5