### PR TITLE
Add searchable provider and certification selects

### DIFF
--- a/static/js/searchable-select.js
+++ b/static/js/searchable-select.js
@@ -1,0 +1,237 @@
+(function(global){
+  if (global.makeSelectSearchable) {
+    return;
+  }
+
+  const STYLE_ID = 'searchable-select-style';
+
+  function ensureStyles(){
+    if (document.getElementById(STYLE_ID)) {
+      return;
+    }
+    const style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.textContent = `
+      .searchable-select-wrapper {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+      .searchable-select-input {
+        width: 100%;
+        padding: 0.55rem 0.75rem;
+        border-radius: 0.75rem;
+        border: 1px solid rgba(255, 255, 255, 0.18);
+        background: rgba(15, 23, 42, 0.35);
+        color: inherit;
+        font: inherit;
+        transition: border-color 0.2s ease, box-shadow 0.2s ease;
+      }
+      .searchable-select-input::placeholder {
+        color: rgba(255, 255, 255, 0.55);
+      }
+      .searchable-select-input:focus {
+        outline: none;
+        border-color: rgba(96, 165, 250, 0.55);
+        box-shadow: 0 0 0 1px rgba(96, 165, 250, 0.35);
+        background: rgba(15, 23, 42, 0.55);
+      }
+      .searchable-select-element {
+        width: 100%;
+      }
+    `;
+    document.head.appendChild(style);
+  }
+
+  function normalizeText(value){
+    return (value == null ? '' : String(value))
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase();
+  }
+
+  function toOptionData(item){
+    if (!item) {
+      return {
+        value: '',
+        label: '',
+        normalizedLabel: '',
+        normalizedValue: '',
+        dataset: {},
+        disabled: false,
+        selected: false
+      };
+    }
+    if (item instanceof HTMLOptionElement) {
+      return {
+        value: item.value,
+        label: item.textContent,
+        normalizedLabel: normalizeText(item.textContent),
+        normalizedValue: normalizeText(item.value),
+        dataset: { ...item.dataset },
+        disabled: item.disabled,
+        selected: item.selected
+      };
+    }
+    const value = item.value ?? item.id ?? '';
+    const label = item.label ?? item.text ?? item.name ?? value;
+    return {
+      value: String(value),
+      label: String(label),
+      normalizedLabel: normalizeText(label),
+      normalizedValue: normalizeText(value),
+      dataset: item.dataset ? { ...item.dataset } : {},
+      disabled: Boolean(item.disabled),
+      selected: Boolean(item.selected)
+    };
+  }
+
+  function createOptionElement(data){
+    const option = document.createElement('option');
+    option.value = data.value;
+    option.textContent = data.label;
+    option.disabled = data.disabled;
+    for (const [key, value] of Object.entries(data.dataset || {})) {
+      option.dataset[key] = value;
+    }
+    return option;
+  }
+
+  function pickSelectableValue(list, explicitValue, previousValue, lastValue){
+    const candidates = new Set(list.map(opt => opt.value));
+    const preferred = [
+      explicitValue,
+      list.find(opt => opt.selected)?.value,
+      previousValue,
+      lastValue
+    ].map(v => (v == null ? null : String(v)));
+    for (const candidate of preferred) {
+      if (candidate != null && candidates.has(candidate)) {
+        return candidate;
+      }
+    }
+    return list.length ? list[0].value : null;
+  }
+
+  function makeSelectSearchable(select, config = {}){
+    if (!(select instanceof HTMLSelectElement)) {
+      return null;
+    }
+
+    if (select.__searchableSelect) {
+      return select.__searchableSelect;
+    }
+
+    ensureStyles();
+
+    const settings = {
+      placeholder: 'Rechercher…',
+      keepSearchOnUpdate: true,
+      ...config
+    };
+
+    const wrapper = document.createElement('div');
+    wrapper.className = 'searchable-select-wrapper';
+
+    const input = document.createElement('input');
+    input.type = 'search';
+    input.autocomplete = 'off';
+    input.className = 'searchable-select-input';
+    input.placeholder = settings.placeholder;
+    input.setAttribute('aria-label', settings.placeholder);
+
+    const parent = select.parentNode;
+    parent.insertBefore(wrapper, select);
+    wrapper.appendChild(input);
+    wrapper.appendChild(select);
+    select.classList.add('searchable-select-element');
+
+    let lastValue = select.value;
+    let masterOptions = Array.from(select.options).map(toOptionData);
+
+    function rebuildOptions(filtered, explicitValue){
+      const previousValue = select.value;
+      select.innerHTML = '';
+      filtered.forEach(optData => {
+        const option = createOptionElement(optData);
+        select.appendChild(option);
+      });
+
+      if (!filtered.length) {
+        select.selectedIndex = -1;
+        lastValue = '';
+        return;
+      }
+
+      const valueToSelect = pickSelectableValue(filtered, explicitValue, previousValue, lastValue);
+      if (valueToSelect != null) {
+        select.value = valueToSelect;
+        lastValue = select.value;
+      }
+    }
+
+    function applyFilter(term, explicitValue){
+      const normalizedTerm = normalizeText(term);
+      const filtered = normalizedTerm
+        ? masterOptions.filter(opt =>
+            opt.normalizedLabel.includes(normalizedTerm) ||
+            opt.normalizedValue.includes(normalizedTerm)
+          )
+        : masterOptions.slice();
+      rebuildOptions(filtered, explicitValue);
+    }
+
+    input.addEventListener('input', () => {
+      applyFilter(input.value);
+    });
+
+    input.addEventListener('keydown', evt => {
+      if (evt.key === 'ArrowDown') {
+        select.focus();
+        evt.preventDefault();
+      }
+    });
+
+    select.addEventListener('change', () => {
+      lastValue = select.value;
+    });
+
+    const api = {
+      select,
+      input,
+      setSearchTerm(term = '') {
+        input.value = term;
+        applyFilter(term, null);
+      },
+      setOptions(options = [], opts = {}) {
+        const { selectedValue = null, keepSearch = true } = opts;
+        masterOptions = (options || []).map(toOptionData);
+        const term = keepSearch ? input.value : '';
+        if (!keepSearch) {
+          input.value = term;
+        }
+        applyFilter(term, selectedValue);
+      },
+      syncFromSelect(opts = {}) {
+        const { keepSearch = true, selectedValue = null } = opts;
+        masterOptions = Array.from(select.options).map(toOptionData);
+        const term = keepSearch ? input.value : '';
+        if (!keepSearch) {
+          input.value = term;
+        }
+        applyFilter(term, selectedValue);
+      },
+      refresh() {
+        applyFilter(input.value, null);
+      }
+    };
+
+    select.__searchableSelect = api;
+
+    applyFilter(input.value, null);
+
+    return api;
+  }
+
+  global.makeSelectSearchable = makeSelectSearchable;
+})(window);

--- a/templates/fix.html
+++ b/templates/fix.html
@@ -272,6 +272,8 @@
     document.querySelectorAll('[data-animate]').forEach(el => observer.observe(el));
   </script>
 
+  <script src="{{ url_for('static', filename='js/searchable-select.js') }}"></script>
+
   <script>
     $(document).ready(function(){
       const $provider = $("#provider_id");
@@ -286,6 +288,9 @@
       const $jobStatus = $("#job-status");
       const $jobIdLabel = $("#job-id-label");
       const $jobLogList = $("#job-log-list");
+
+      const providerSearch = window.makeSelectSearchable ? window.makeSelectSearchable($provider[0], { placeholder: 'Rechercher un provider…' }) : null;
+      const certSearch = window.makeSelectSearchable ? window.makeSelectSearchable($cert[0], { placeholder: 'Rechercher une certification…' }) : null;
 
       let initialProgress = {{ initial_progress|tojson }};
       const preloadedCertId = "{{ selected_cert_id if selected_cert_id is not none else '' }}";
@@ -438,15 +443,27 @@
 
       function loadCertifications(providerId, selectedCertId){
         $.post("{{ url_for('fix_get_certifications') }}", { provider_id: providerId }, function(data){
-          $cert.empty();
-          $.each(data || [], function(i, item){
-            const option = $("<option>", { value: item.id, text: item.name });
-            if(Number(selectedCertId) === Number(item.id)){
-              option.prop('selected', true);
-            }
-            $cert.append(option);
-          });
-          $cert.trigger('change');
+          const items = (data || []).map(item => ({
+            value: item.id,
+            label: item.name,
+            selected: Number(selectedCertId) === Number(item.id)
+          }));
+          if (certSearch) {
+            const list = items.length ? items : [{ value: '', label: '— Aucune certification —' }];
+            const selectedValue = list.find(opt => opt.selected)?.value ?? list[0]?.value ?? '';
+            certSearch.setOptions(list, { keepSearch: false, selectedValue });
+            certSearch.select.dispatchEvent(new Event('change'));
+          } else {
+            $cert.empty();
+            $.each(items.length ? items : [{ value: '', label: '— Aucune certification —' }], function(_, optionData){
+              const option = $("<option>", { value: optionData.value, text: optionData.label });
+              if (optionData.selected) {
+                option.prop('selected', true);
+              }
+              $cert.append(option);
+            });
+            $cert.trigger('change');
+          }
         }, "json");
       }
 

--- a/templates/import_modules.html
+++ b/templates/import_modules.html
@@ -530,6 +530,8 @@
 
   <footer>ExBoot Laboratory &mdash; Importer des modules n'a jamais été aussi sensoriel.</footer>
 
+  <script src="{{ url_for('static', filename='js/searchable-select.js') }}"></script>
+
   <script>
     const toggle = document.getElementById('navToggle');
     const nav = document.getElementById('stellarNav');
@@ -604,13 +606,18 @@
     }
 
     function fill(select, items) {
-      select.innerHTML = '';
-      items.forEach(item => {
-        const option = document.createElement('option');
-        option.value = item.id;
-        option.textContent = item.name;
-        select.appendChild(option);
-      });
+      const helper = select && select.__searchableSelect;
+      if (helper) {
+        helper.setOptions((items || []).map(item => ({ value: item.id, label: item.name })), { keepSearch: false });
+      } else {
+        select.innerHTML = '';
+        (items || []).forEach(item => {
+          const option = document.createElement('option');
+          option.value = item.id;
+          option.textContent = item.name;
+          select.appendChild(option);
+        });
+      }
     }
 
     function setGenerationStatus(message, tone = 'muted') {
@@ -674,6 +681,9 @@
       const provSel = document.getElementById('prov');
       const certSel = document.getElementById('cert');
 
+      const provSearch = window.makeSelectSearchable ? window.makeSelectSearchable(provSel, { placeholder: 'Rechercher un provider…' }) : null;
+      const certSearch = window.makeSelectSearchable ? window.makeSelectSearchable(certSel, { placeholder: 'Rechercher une certification…' }) : null;
+
       function updateSelectionLabel() {
         selectionLabel.textContent = `${provSel.options[provSel.selectedIndex]?.text || ''} → ${certSel.options[certSel.selectedIndex]?.text || '—'}`;
       }
@@ -682,6 +692,7 @@
         try {
           const certs = await loadJSON(`${base}api/certifications/${provSel.value}`);
           fill(certSel, certs);
+          certSearch && certSearch.setSearchTerm('');
           if (certs.length) {
             certSel.value = certs[0].id;
             updateSelectionLabel();
@@ -701,6 +712,7 @@
       try {
         const providers = await loadJSON(base + 'api/providers');
         fill(provSel, providers);
+        provSearch && provSearch.setSearchTerm('');
         if (providers.length) {
           provSel.value = providers[0].id;
           await refreshProviderCertifications();

--- a/templates/move_questions.html
+++ b/templates/move_questions.html
@@ -243,6 +243,8 @@
 
   <footer>ExBoot Laboratory &mdash; La mobilité des questions devient un art.</footer>
 
+  <script src="{{ url_for('static', filename='js/searchable-select.js') }}"></script>
+
   <script>
     const toggle = document.getElementById('navToggle');
     const nav = document.getElementById('stellarNav');
@@ -280,19 +282,24 @@
     }
 
     function fillSelect(el, items, addAll = false) {
-      el.innerHTML = '';
+      const helper = el && el.__searchableSelect;
+      const data = [];
       if (addAll) {
-        const opt = document.createElement('option');
-        opt.value = '__all__';
-        opt.text = '— Tous —';
-        el.appendChild(opt);
+        data.push({ value: '__all__', label: '— Tous —' });
       }
-      items.forEach(i => {
-        const o = document.createElement('option');
-        o.value = i.id;
-        o.text = i.name;
-        el.appendChild(o);
-      });
+      (items || []).forEach(i => data.push({ value: i.id, label: i.name }));
+
+      if (helper) {
+        helper.setOptions(data, { keepSearch: false });
+      } else {
+        el.innerHTML = '';
+        data.forEach(item => {
+          const o = document.createElement('option');
+          o.value = item.value;
+          o.text = item.label;
+          el.appendChild(o);
+        });
+      }
     }
 
     const base = '{{ url_for('move.index') }}';
@@ -303,8 +310,12 @@
       const dom = document.getElementById(prefix + '-dom');
       const isSource = prefix === 'src';
 
+      const provSearch = window.makeSelectSearchable ? window.makeSelectSearchable(prov, { placeholder: 'Rechercher un provider…' }) : null;
+      const certSearch = window.makeSelectSearchable ? window.makeSelectSearchable(cert, { placeholder: 'Rechercher une certification…' }) : null;
+
       const provs = await loadJSON(base + 'api/providers');
       fillSelect(prov, provs);
+      provSearch && provSearch.setSearchTerm('');
       if (provs.length) {
         prov.value = provs[0].id;
         prov.dispatchEvent(new Event('change'));
@@ -313,6 +324,7 @@
       prov.addEventListener('change', async () => {
         const cs = await loadJSON(`${base}api/certifications/${prov.value}`);
         fillSelect(cert, cs);
+        certSearch && certSearch.setSearchTerm('');
         if (cs.length) {
           cert.value = cs[0].id;
           cert.dispatchEvent(new Event('change'));

--- a/templates/pdf_generate.html
+++ b/templates/pdf_generate.html
@@ -264,6 +264,8 @@
 
   <div id="loadingOverlay"><div class="loader"></div></div>
 
+  <script src="{{ url_for('static', filename='js/searchable-select.js') }}"></script>
+
   <script>
     const toggle = document.getElementById('navToggle');
     const nav = document.getElementById('stellarNav');
@@ -304,29 +306,64 @@
     const genUrl = '{{ url_for('pdf.generate_questions_from_pdf') }}';
     let currentSession = null;
 
+    const providerSelect = document.getElementById("providerSelect");
+    const certSelect = document.getElementById("certSelect");
+    const providerSearch = window.makeSelectSearchable ? window.makeSelectSearchable(providerSelect, { placeholder: 'Rechercher un provider…' }) : null;
+    const certSearch = window.makeSelectSearchable ? window.makeSelectSearchable(certSelect, { placeholder: 'Rechercher une certification…' }) : null;
+
     fetch(base + "api/providers").then(r => r.json()).then(data => {
-        const providerSelect = document.getElementById("providerSelect");
-        providerSelect.innerHTML = "";
-        data.forEach(p => providerSelect.appendChild(option(p.name, p.id)));
-        if (data.length > 0) {
-            providerSelect.value = data[0].id;
-            providerSelect.dispatchEvent(new Event("change"));
+        const items = (data || []).map(p => ({ value: p.id, label: p.name }));
+        const list = items.length ? items : [{ value: '', label: '— Aucun provider —' }];
+        const selectedValue = list[0]?.value ?? '';
+        if (providerSearch) {
+            providerSearch.setOptions(list, { keepSearch: false, selectedValue });
+            providerSearch.select.dispatchEvent(new Event("change"));
+        } else {
+            providerSelect.innerHTML = "";
+            list.forEach(opt => providerSelect.appendChild(option(opt.label, opt.value)));
+            if (list.length) {
+                providerSelect.value = selectedValue;
+                providerSelect.dispatchEvent(new Event("change"));
+            }
         }
     });
 
-    document.getElementById("providerSelect").addEventListener("change", function(){
+    providerSelect.addEventListener("change", function(){
         const prov_id = this.value;
-        const certSelect = document.getElementById("certSelect");
         const domSelect = document.getElementById("domainSelect");
-        certSelect.innerHTML = ""; domSelect.innerHTML = "";
-        if (!prov_id) return;
+        domSelect.innerHTML = "";
+        if (certSearch) {
+            certSearch.setOptions([], { keepSearch: false, selectedValue: '' });
+        } else {
+            certSelect.innerHTML = "";
+        }
+        if (!prov_id) {
+            if (!certSearch) {
+                certSelect.appendChild(option('— Aucune certification —', ''));
+            } else {
+                certSearch.setOptions([{ value: '', label: '— Aucune certification —' }], { keepSearch: false, selectedValue: '' });
+            }
+            return;
+        }
         fetch(`${base}api/certifications/${prov_id}`).then(r=>r.json()).then(data=>{
-            data.forEach(c => certSelect.appendChild(option(c.name, c.id)));
-            if (data.length>0){ certSelect.value = data[0].id; certSelect.dispatchEvent(new Event("change")); }
+            const items = (data || []).map(c => ({ value: c.id, label: c.name }));
+            const list = items.length ? items : [{ value: '', label: '— Aucune certification —' }];
+            const selectedValue = list[0]?.value ?? '';
+            if (certSearch) {
+                certSearch.setOptions(list, { keepSearch: false, selectedValue });
+                certSearch.select.dispatchEvent(new Event("change"));
+            } else {
+                certSelect.innerHTML = "";
+                list.forEach(opt => certSelect.appendChild(option(opt.label, opt.value)));
+                if (list.length) {
+                    certSelect.value = selectedValue;
+                    certSelect.dispatchEvent(new Event("change"));
+                }
+            }
         });
     });
 
-    document.getElementById("certSelect").addEventListener("change", function(){
+    certSelect.addEventListener("change", function(){
         const cert_id = this.value;
         const domSelect = document.getElementById("domainSelect");
         domSelect.innerHTML = "";

--- a/templates/populate.html
+++ b/templates/populate.html
@@ -279,15 +279,31 @@
     document.querySelectorAll('[data-animate]').forEach(el => observer.observe(el));
   </script>
 
+  <script src="{{ url_for('static', filename='js/searchable-select.js') }}"></script>
+
   {% if not is_populating %}
   <script>
     $(document).ready(function(){
+      const providerEl = document.getElementById('provider_id');
+      const certEl = document.getElementById('cert_id');
+      const providerSearch = window.makeSelectSearchable ? window.makeSelectSearchable(providerEl, { placeholder: 'Rechercher un provider…' }) : null;
+      const certSearch = window.makeSelectSearchable ? window.makeSelectSearchable(certEl, { placeholder: 'Rechercher une certification…' }) : null;
+
       $("#provider_id").change(function(){
         $.post("{{ url_for('get_certifications') }}", { provider_id: $(this).val() }, function(data){
-          $("#cert_id").empty();
-          $.each(data || [], function(i, item){
-            $("#cert_id").append($("<option>", { value: item.id, text : item.name }));
-          });
+          const items = (data || []).map(item => ({ value: item.id, label: item.name }));
+          if (certSearch) {
+            const list = items.length ? items : [{ value: '', label: '— Aucune certification —' }];
+            certSearch.setOptions(list, { keepSearch: false, selectedValue: list[0]?.value ?? '' });
+            certSearch.select.dispatchEvent(new Event('change'));
+          } else {
+            const $cert = $("#cert_id");
+            $cert.empty();
+            $.each(items.length ? items : [{ value: '', label: '— Aucune certification —' }], function(_, optionData){
+              $cert.append($("<option>", { value: optionData.value, text : optionData.label }));
+            });
+            $cert.trigger('change');
+          }
         }, "json");
       }).trigger('change');
     });

--- a/templates/reloc.html
+++ b/templates/reloc.html
@@ -224,6 +224,8 @@
 
   <footer>ExBoot Laboratory &mdash; La relocalisation IA devient fluide et lumineuse.</footer>
 
+  <script src="{{ url_for('static', filename='js/searchable-select.js') }}"></script>
+
   <script>
     const toggle = document.getElementById('navToggle');
     const nav = document.getElementById('stellarNav');
@@ -257,12 +259,17 @@
 
     async function loadJSON(u){ return (await fetch(u)).json(); }
     function fill(el, items){
-      el.innerHTML = '';
-      items.forEach(i=>{
-        const o = document.createElement('option');
-        o.value = i.id; o.text = i.name;
-        el.appendChild(o);
-      });
+      const helper = el && el.__searchableSelect;
+      if (helper) {
+        helper.setOptions((items || []).map(i => ({ value: i.id, label: i.name })), { keepSearch: false });
+      } else {
+        el.innerHTML = '';
+        (items || []).forEach(i=>{
+          const o = document.createElement('option');
+          o.value = i.id; o.text = i.name;
+          el.appendChild(o);
+        });
+      }
     }
 
     async function initPanel(pref, hasModule, defProv=null, defCert=null){
@@ -271,10 +278,14 @@
       const m = hasModule && document.getElementById(pref+'-mod');
       const s = hasModule && document.getElementById(pref+'-mod-search');
 
+      const provSearch = window.makeSelectSearchable ? window.makeSelectSearchable(p, { placeholder: 'Rechercher un provider…' }) : null;
+      const certSearch = window.makeSelectSearchable ? window.makeSelectSearchable(c, { placeholder: 'Rechercher une certification…' }) : null;
+
       const base = '{{ url_for('reloc.index') }}';
       p.addEventListener('change', async()=>{
         const cs = await loadJSON(`${base}api/certifications/${p.value}`);
         fill(c, cs);
+        certSearch && certSearch.setSearchTerm('');
         let sel = cs[0]?.id;
         if(Number(p.value) === defProv){
           const found = cs.find(x=>x.id===defCert);
@@ -302,6 +313,7 @@
 
       const provs = await loadJSON(base + 'api/providers');
       fill(p, provs);
+      provSearch && provSearch.setSearchTerm('');
       p.value = provs.find(x=>x.id===defProv)?.id || provs[0]?.id;
       p.dispatchEvent(new Event('change'));
     }

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -227,6 +227,8 @@
 
   <div id="loadingOverlay"><div class="loader"></div></div>
 
+  <script src="{{ url_for('static', filename='js/searchable-select.js') }}"></script>
+
   <script>
     const toggle = document.getElementById('navToggle');
     const nav = document.getElementById('stellarNav');
@@ -266,55 +268,97 @@
 
     const base = '{{ url_for('pdf.index') }}';
 
+    const providerSelect = document.getElementById("providerSelect");
+    const certSelect = document.getElementById("certSelect");
+    const providerSearch = window.makeSelectSearchable ? window.makeSelectSearchable(providerSelect, { placeholder: 'Rechercher un provider…' }) : null;
+    const certSearch = window.makeSelectSearchable ? window.makeSelectSearchable(certSelect, { placeholder: 'Rechercher une certification…' }) : null;
+
     fetch(base + "api/providers").then(r => r.json()).then(data => {
-        const providerSelect = document.getElementById("providerSelect");
-        providerSelect.innerHTML = "";
-        if (!data || data.length === 0) {
-            providerSelect.appendChild(option("— Aucun provider —", ""));
-            return;
+        const items = (data || []).map(p => ({ value: p.id, label: p.name }));
+        const defProv = items.find(p => Number(p.value) === 169);
+        const list = items.length ? items : [{ value: '', label: '— Aucun provider —' }];
+        const selectedValue = defProv ? defProv.value : (list[0]?.value ?? '');
+        if (providerSearch) {
+            providerSearch.setOptions(list, { keepSearch: false, selectedValue });
+            providerSearch.select.dispatchEvent(new Event("change"));
+        } else {
+            providerSelect.innerHTML = "";
+            list.forEach(opt => providerSelect.appendChild(option(opt.label, opt.value)));
+            if (list.length) {
+                providerSelect.value = selectedValue;
+                providerSelect.dispatchEvent(new Event("change"));
+            }
         }
-        data.forEach(p => providerSelect.appendChild(option(p.name, p.id)));
-        const defProv = data.find(p => p.id === 169);
-        providerSelect.value = defProv ? defProv.id : data[0].id;
-        providerSelect.dispatchEvent(new Event("change"));
     });
 
-    document.getElementById("providerSelect").addEventListener("change", function () {
+    providerSelect.addEventListener("change", function () {
         const prov_id = this.value;
-        const certSelect = document.getElementById("certSelect");
         const modSelect  = document.getElementById("moduleSelect");
 
-        certSelect.innerHTML = "";
         modSelect.innerHTML  = "";
+        if (certSearch) {
+            certSearch.setOptions([], { keepSearch: false, selectedValue: '' });
+        } else {
+            certSelect.innerHTML = "";
+        }
 
         if (!prov_id) {
-            certSelect.appendChild(option("— Aucune certification —", ""));
+            const fallbackCert = { value: '', label: '— Aucune certification —' };
+            if (certSearch) {
+                certSearch.setOptions([fallbackCert], { keepSearch: false, selectedValue: '' });
+            } else {
+                certSelect.appendChild(option(fallbackCert.label, fallbackCert.value));
+            }
             modSelect.appendChild(option("— Aucun module —", ""));
             return;
         }
 
         fetch(`${base}api/certifications/${prov_id}`).then(r => r.json()).then(data => {
-            certSelect.innerHTML = "";
-            if (!data || data.length === 0) {
-                certSelect.appendChild(option("— Aucune certification —", ""));
-                modSelect.appendChild(option("— Aucun module —", ""));
-                return;
+            const items = (data || []).map(c => ({ value: c.id, label: c.name }));
+            let list = items.length ? items : [{ value: '', label: '— Aucune certification —' }];
+            if (items.length && Number(prov_id) === 169) {
+                const defCert = items.find(c => Number(c.value) === 23);
+                if (defCert) {
+                    list = items;
+                    const selectedValue = defCert.value;
+                    if (certSearch) {
+                        certSearch.setOptions(list, { keepSearch: false, selectedValue });
+                        certSearch.select.dispatchEvent(new Event("change"));
+                    } else {
+                        certSelect.innerHTML = "";
+                        list.forEach(opt => certSelect.appendChild(option(opt.label, opt.value)));
+                        certSelect.value = selectedValue;
+                        certSelect.dispatchEvent(new Event("change"));
+                    }
+                    return;
+                }
             }
-            data.forEach(c => certSelect.appendChild(option(c.name, c.id)));
-            let sel = data[0].id;
-            if (Number(prov_id) === 169) {
-                const defCert = data.find(c => c.id === 23);
-                if (defCert) sel = defCert.id;
+
+            const selectedValue = list[0]?.value ?? '';
+            if (certSearch) {
+                certSearch.setOptions(list, { keepSearch: false, selectedValue });
+                certSearch.select.dispatchEvent(new Event("change"));
+            } else {
+                certSelect.innerHTML = "";
+                list.forEach(opt => certSelect.appendChild(option(opt.label, opt.value)));
+                certSelect.value = selectedValue;
+                certSelect.dispatchEvent(new Event("change"));
             }
-            certSelect.value = sel;
-            certSelect.dispatchEvent(new Event("change"));
         }).catch(() => {
-            certSelect.innerHTML = ""; modSelect.innerHTML = "";
-            certSelect.appendChild(option("— Erreur chargement —", ""));
+            if (certSearch) {
+                certSearch.setOptions([{ value: '', label: '— Erreur chargement —' }], { keepSearch: false, selectedValue: '' });
+                certSearch.select.dispatchEvent(new Event("change"));
+            } else {
+                certSelect.innerHTML = "";
+                certSelect.appendChild(option("— Erreur chargement —", ""));
+                certSelect.dispatchEvent(new Event("change"));
+            }
+            modSelect.innerHTML = "";
+            modSelect.appendChild(option("— Aucun module —", ""));
         });
     });
 
-    document.getElementById("certSelect").addEventListener("change", function () {
+    certSelect.addEventListener("change", function () {
         const cert_id = this.value;
         const modSelect = document.getElementById("moduleSelect");
 


### PR DESCRIPTION
## Summary
- add a reusable searchable-select helper script for enhanced dropdown filtering
- enable provider and certification search inputs across population, fix, PDF import/generation, relocation, module import, and move question workflows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d81cb81db08325bd5a3a322e4eac6b