### PR TITLE
Add local fallback when Celery queue is unavailable

### DIFF
--- a/app.py
+++ b/app.py
@@ -744,6 +744,48 @@ def run_population_job(self, provider_id: int, cert_id: int) -> None:
         context.set_status("completed")
 
 
+def _run_population_thread(job_id: str, provider_id: int, cert_id: int) -> threading.Thread:
+    """Run the population workflow in a local background thread.
+
+    When the Celery broker is unavailable (for instance when Redis refuses
+    new clients because the configured limit is reached) we still want to
+    allow the user to launch the populate process.  This helper mimics the
+    behaviour of :func:`run_population_job` but executes it within a daemon
+    thread of the web process so that the HTTP request can return immediately.
+    """
+
+    metadata = {"provider_id": provider_id, "cert_id": cert_id}
+
+    def _target() -> None:
+        context = JobContext(job_store, job_id)
+        try:
+            job_store.set_status(job_id, "running")
+        except JobStoreError:
+            initialise_job(
+                job_store,
+                job_id=job_id,
+                description="populate-certification",
+                metadata=metadata,
+            )
+            job_store.set_status(job_id, "running")
+
+        try:
+            run_population(context, provider_id, cert_id)
+        except Exception as exc:  # pragma: no cover - logged for diagnostics
+            app.logger.exception(
+                "Population job failed during local execution: job_id=%s", job_id
+            )
+            context.set_status("failed", error=str(exc))
+        else:
+            context.set_status("completed")
+
+    thread = threading.Thread(
+        target=_target, name=f"populate-{job_id}", daemon=True
+    )
+    thread.start()
+    return thread
+
+
 @app.route("/populate/process", methods=["POST"])
 def populate_process():
     provider_id = int(request.form.get("provider_id"))
@@ -762,16 +804,24 @@ def populate_process():
         app.logger.exception(
             "Unable to enqueue population job: provider_id=%s cert_id=%s", provider_id, cert_id
         )
-        job_store.set_status(job_id, "failed", error=str(exc))
-        return (
-            jsonify(
-                {
-                    "error": "Impossible de démarrer le traitement : "
-                    "la file d'attente des tâches est indisponible."
-                }
-            ),
-            500,
+        try:
+            _run_population_thread(job_id, provider_id, cert_id)
+        except Exception:  # pragma: no cover - fallback may still fail
+            job_store.set_status(job_id, "failed", error=str(exc))
+            return (
+                jsonify(
+                    {
+                        "error": "Impossible de démarrer le traitement : "
+                        "la file d'attente des tâches est indisponible."
+                    }
+                ),
+                500,
+            )
+        app.logger.warning(
+            "Population job %s running in local thread because the task queue is unavailable.",
+            job_id,
         )
+        return jsonify({"status": "queued", "job_id": job_id, "mode": "local"})
     except Exception as exc:
         if getattr(celery_app.conf, "task_always_eager", False):
             app.logger.exception(


### PR DESCRIPTION
## Summary
- add a local background thread helper that mirrors the population Celery task
- fall back to running the population job locally when enqueuing fails because the task queue is unavailable
- log the fallback execution so operators know Redis/Celery connectivity needs attention

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d961e42004832591fe3ed56365630b